### PR TITLE
fix operation id typo for authn sdk docs

### DIFF
--- a/packages/pangea-sdk/PangeaCyber.Net/AuthN/Clients/ClientSession.cs
+++ b/packages/pangea-sdk/PangeaCyber.Net/AuthN/Clients/ClientSession.cs
@@ -18,7 +18,7 @@ namespace PangeaCyber.Net.AuthN.Clients
         /// <kind>method</kind>
         /// <summary>Invalidate a session by session ID using a client token.</summary>
         /// <remarks>Invalidate Session | Client</remarks>
-        /// <operationid>authn_post_v2_client_password_change</operationid>
+        /// <operationid>authn_post_v2_client_session_invalidate</operationid>
         /// <param name="token" type="string">A user token value</param>
         /// <param name="sessionID" type="string">An ID for a token</param>
         /// <returns>Response&lt;ClientSessionInvalidateResult&gt;</returns>

--- a/packages/pangea-sdk/PangeaCyber.Net/docsgen/source/PangeaCyber.Net.xml
+++ b/packages/pangea-sdk/PangeaCyber.Net/docsgen/source/PangeaCyber.Net.xml
@@ -11,10 +11,10 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.ArweaveRequest.query">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.arweave.ArweaveRequest.#ctor(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.Arweave">
             <kind>class</kind>
@@ -23,16 +23,16 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.Audit.arweave.Arweave.BaseURL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Arweave.TreeName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.arweave.Arweave.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.arweave.Arweave.GetPublishedRoots(System.Int32[])">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.GraphqlOutput">
             <kind>class</kind>
@@ -41,43 +41,43 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.GraphqlOutput.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.Data">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Data.Transactions">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.Transactions">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Transactions.Edges">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.Edge">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Edge.Node">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.Node">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Node.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Node.Tags">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.Tag">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Tag.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.Tag.Value">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.arweave.PublishedRoot">
             <kind>class</kind>
@@ -86,25 +86,25 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.PublishedRoot.Size">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.PublishedRoot.RootHash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.PublishedRoot.PublishedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.PublishedRoot.ConsistencyProof">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.arweave.PublishedRoot.Source">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.arweave.PublishedRoot.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.arweave.PublishedRoot.#ctor(System.Int32,System.String,System.String,System.String[],System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.AuditClient">
             <kind>class</kind>
@@ -113,28 +113,28 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.AuditClient.ServiceName">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.Signer">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.PublishedRoots">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.AllowServerRoots">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.PrevUnpublishedRoot">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.TenantID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.CustomSchemaClass">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.PKInfo">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.#ctor(PangeaCyber.Net.Audit.AuditClient.Builder)">
             Constructor
@@ -156,11 +156,11 @@
              string msg = "hello world";
              var event = new StandardEvent.Builder(msg)
                  .Build();
-
+            
              var config = new LogConfig.Builder()
                  .WithVerbose(true)
                  .Build();
-
+            
              var response = await client.Log(event, config);
              </code>
              </example>
@@ -181,7 +181,7 @@
              <code>
              var event = new StandardEvent.Builder("hello world").Build();
              StandardEvent[] events = {event};
-
+            
              var response = await client.LogBulk(events, new LogConfig.Builder().Build());
              </code>
              </example>
@@ -202,7 +202,7 @@
              <code>
              var event = new StandardEvent.Builder("hello world").Build();
              StandardEvent[] events = {event};
-
+            
              var response = await client.LogBulkAsync(events, new LogConfig.Builder().Build());
              </code>
              </example>
@@ -253,7 +253,7 @@
              var config = new SearchConfig
                  .Builder()
                  .Build();
-
+            
              var response = await client.Search(request, config);
              </code>
              </example>
@@ -276,7 +276,7 @@
              var config = new SearchConfig
                  .Builder()
                  .Build();
-
+            
              var response = await client.Results(request, config);
              </code>
              </example>
@@ -288,22 +288,22 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.Builder.privateKeyFilename">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.Builder.tenantID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.Builder.customSchemaClass">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.Builder.pkInfo">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.AuditClient.Builder.configID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.Builder.WithPrivateKey(System.String)">
             Add a private key in case want to use local signature
@@ -330,31 +330,31 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.EventEnvelope.Event">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.EventEnvelope.Signature">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.EventEnvelope.PublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.EventEnvelope.ReceivedAt">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.EventEnvelope.#ctor(PangeaCyber.Net.Audit.IEvent,System.String,System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.EventEnvelope.VerifySignature">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.EventEnvelope.FromRaw(System.Collections.Generic.Dictionary{System.String,System.Object},System.Type)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.EventEnvelope.VerifyHash(System.Object,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.EventEnvelope.Canonicalize(System.Object)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.IEvent">
             <kind>class</kind>
@@ -363,61 +363,61 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.IEvent.TenantID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.IEvent.SetTenantID(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.IEvent.GetTenantID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.IEvent.Canonicalize(PangeaCyber.Net.Audit.IEvent)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.IEvent.FromRaw(System.Object,System.Type)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogConfig">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogConfig.SignLocal">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogConfig.Verify">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogConfig.Verbose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogConfig.#ctor(PangeaCyber.Net.Audit.LogConfig.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogConfig.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogConfig.Builder.SignLocal">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogConfig.Builder.Verify">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogConfig.Builder.Verbose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogConfig.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogConfig.Builder.WithSignLocal(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogConfig.Builder.WithVerify(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogConfig.Builder.WithVerbose(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogConfig.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogSigner">
             <kind>enum</kind>
@@ -426,25 +426,25 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.Audit.LogSigner.PrivateKeyFilename">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.LogSigner.PrivateKey">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Audit.LogSigner.PublicKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogSigner.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogSigner.Sign(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogSigner.GetPublicKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogSigner.GetAlgorithm">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.Root">
             <kind>class</kind>
@@ -453,55 +453,55 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.Root.TreeName">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Root.Size">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Root.RootHash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Root.URL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Root.PublishedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Root.ConsistencyProof">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchConfig">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchConfig.VerifyConsistency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchConfig.VerifyEvents">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchConfig.#ctor(PangeaCyber.Net.Audit.SearchConfig.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchConfig.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchConfig.Builder.VerifyConsistency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchConfig.Builder.VerifyEvents">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchConfig.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchConfig.Builder.WithVerifyConsistency(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchConfig.Builder.WithVerifyEvents(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchConfig.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchEvent">
             <kind>class</kind>
@@ -510,40 +510,40 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.RawEnvelope">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.EventEnvelope">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.Hash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.LeafIndex">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.MembershipProof">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.Published">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.MembershipVerification">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.ConsistencyVerification">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchEvent.SignatureVerification">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchEvent.VerifySignature">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchEvent.VerifyConsistency(System.Collections.Generic.Dictionary{System.Int32,PangeaCyber.Net.Audit.arweave.PublishedRoot})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchEvent.VerifyMembershipProof(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchRestriction">
             <kind>class</kind>
@@ -552,19 +552,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRestriction.Actor">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRestriction.source">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRestriction.target">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRestriction.status">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRestriction.action">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.StandardEvent">
             <kind>class</kind>
@@ -573,103 +573,103 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Actor">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Action">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Message">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.NewField">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Old">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Source">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Status">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Target">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Timestamp">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.#ctor(PangeaCyber.Net.Audit.StandardEvent.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.#ctor(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.StandardEvent.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Actor">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Action">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Message">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.NewField">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Old">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Source">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Status">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Target">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.Timestamp">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.StandardEvent.Builder.TenantID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithActor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithAction(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithNewField(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithOld(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithSource(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithStatus(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithTarget(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithTimestamp(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.WithTenantID(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.StandardEvent.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.Verifier">
             <kind>class</kind>
@@ -678,7 +678,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Audit.Verifier.Verify(System.String,System.String,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogBulkRequest">
             <kind>class</kind>
@@ -687,13 +687,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogBulkRequest.Events">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogBulkRequest.Verbose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogBulkRequest.#ctor(PangeaCyber.Net.Audit.LogEvent[],System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogEvent">
             <kind>class</kind>
@@ -702,16 +702,16 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogEvent.Event">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogEvent.Signature">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogEvent.PublicKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogEvent.#ctor(PangeaCyber.Net.Audit.IEvent,System.String,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogRequest">
             <kind>class</kind>
@@ -720,58 +720,58 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogRequest.event">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogRequest.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogRequest.Signature">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogRequest.PublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogRequest.PrevRoot">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogRequest.#ctor(PangeaCyber.Net.Audit.IEvent,System.Boolean,System.String,System.String,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.ResultRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultRequest.Id">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultRequest.Limit">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultRequest.Offset">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.ResultRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultRequest.Builder.Id">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultRequest.Builder.Limit">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultRequest.Builder.Offset">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.ResultRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.ResultRequest.Builder.WithLimit(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.ResultRequest.Builder.WithOffset(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.ResultRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.RootRequest">
             <kind>class</kind>
@@ -780,103 +780,103 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.Audit.RootRequest.TreeSize">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.RootRequest.#ctor(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Query">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.End">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Limit">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.MaxResults">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.SearchRestriction">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Verbose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.#ctor(PangeaCyber.Net.Audit.SearchRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.Query">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.End">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.Limit">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.MaxResults">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.SearchRestriction">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchRequest.Builder.Verbose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithOrder(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithOrderBy(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithStart(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithEnd(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithLimit(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithMaxResults(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithSearchRestriction(PangeaCyber.Net.Audit.SearchRestriction)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.WithVerbose(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.SearchRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogBulkResult">
             <kind>class</kind>
@@ -885,7 +885,7 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogBulkResult.Results">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.LogResult">
             <kind>class</kind>
@@ -894,34 +894,34 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.RawEnvelope">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.EventEnvelope">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.Hash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.UnpublishedRoot">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.MembershipProof">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.ConsistencyProof">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.MembershipVerification">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.ConsistencyVerification">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.LogResult.SignatureVerification">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.LogResult.VerifySignature">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.ResultsOutput">
             <kind>class</kind>
@@ -930,16 +930,16 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultsOutput.Count">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultsOutput.Events">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultsOutput.Root">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.ResultsOutput.UnpublishedRoot">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.RootResult">
             <kind>class</kind>
@@ -948,7 +948,7 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.RootResult.Root">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.SearchOutput">
             <kind>class</kind>
@@ -957,10 +957,10 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchOutput.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.SearchOutput.ExpiresAt">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.Utils.ConsistencyProof">
             <kind>class</kind>
@@ -975,13 +975,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.Utils.ConsistencyProofItem.Hash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Utils.ConsistencyProofItem.MembershipProof">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.ConsistencyProofItem.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.Utils.Hash">
             <kind>class</kind>
@@ -990,16 +990,16 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Hash.GetHash(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Hash.Unhexlify(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Hash.Decode(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Hash.GetHash(System.Byte[],System.Byte[])">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.Utils.MembershipProof">
             <kind>class</kind>
@@ -1014,13 +1014,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Audit.Utils.MembershipProofItem.Side">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Audit.Utils.MembershipProofItem.Hash">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.MembershipProofItem.#ctor(System.String,System.Byte[])">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Audit.Utils.Verification">
             <kind>class</kind>
@@ -1029,16 +1029,16 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Verification.VerifyMembershipProof(System.String,System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Verification.DecodeMembershipProof(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Verification.DecodeConsistencyProof(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Audit.Utils.Verification.VerifyConsistencyProof(System.String,System.String,PangeaCyber.Net.Audit.Utils.ConsistencyProof)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.EventVerification">
             <kind>enum</kind>
@@ -1047,13 +1047,13 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.EventVerification.Success">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.EventVerification.Failed">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.EventVerification.NotVerified">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.AuthNClient">
             <kind>class</kind>
@@ -1062,31 +1062,31 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.AuthNClient.User">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.AuthNClient.Flow">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.AuthNClient.Client">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.AuthNClient.Session">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.AuthNClient.Agreements">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.AuthNClient.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.AuthNClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.AuthNClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.AuthNClient.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Clients.Agreements">
             <kind>class</kind>
@@ -1095,7 +1095,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Agreements.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Agreements.Create(PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest)">
             <kind>method</kind>
@@ -1111,7 +1111,7 @@
                 "EULA_V1",
                 "You agree to behave yourself while logged in.")
             .Build();
-
+            
             var response = await client.Agreements.Create(request);
             </code>
             </example>
@@ -1126,10 +1126,10 @@
             <example>
             <code>
             var request = new AgreementDeleteRequest.Builder(
-                AgreementType.EULA,
+                AgreementType.EULA, 
                 "peu_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a")
             .Build();
-
+            
             var response = await client.Agreements.Delete(request);
             </code>
             </example>
@@ -1148,7 +1148,7 @@
                 "peu_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a")
             .WithText("You agree to behave yourself while logged in. Don't be evil.")
             .Build();
-
+            
             var response = await client.Agreements.Update(request);
             </code>
             </example>
@@ -1163,7 +1163,7 @@
             <example>
             <code>
             var request = new AgreementListRequest.Builder().Build();
-
+            
             var response = await client.Agreements.List(request);
             </code>
             </example>
@@ -1175,16 +1175,16 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.AuthNBaseClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.AuthNBaseClient.#ctor(PangeaCyber.Net.AuthN.Clients.AuthNBaseClient.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Clients.AuthNBaseClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.AuthNBaseClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Clients.Client">
             <kind>class</kind>
@@ -1193,16 +1193,16 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.Client.Session">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.Client.Password">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.Client.Token">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Client.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Client.Userinfo(System.String)">
             <kind>method</kind>
@@ -1236,7 +1236,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.ClientPassword.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.ClientPassword.Change(System.String,System.String,System.String)">
             <kind>method</kind>
@@ -1263,20 +1263,20 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.ClientSession.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.ClientSession.Invalidate(System.String,System.String)">
             <kind>method</kind>
             <summary>Invalidate a session by session ID using a client token.</summary>
             <remarks>Invalidate Session | Client</remarks>
-            <operationid>authn_post_v2_client_password_change</operationid>
+            <operationid>authn_post_v2_client_session_invalidate</operationid>
             <param name="token" type="string">A user token value</param>
             <param name="sessionID" type="string">An ID for a token</param>
             <returns>Response&lt;ClientSessionInvalidateResult&gt;</returns>
             <example>
             <code>
             var response = await client.Client.Session.Invalidate(
-                "ptu_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a",
+                "ptu_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a", 
                 "pmt_zppkzrjguxyblaia6itbiesejn7jejnr");
             </code>
             </example>
@@ -1293,7 +1293,7 @@
             var request = new ClientSessionListRequest
                 .Builder("ptu_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a")
                 .Build();
-
+            
             var response = await client.Client.Session.List(request);
             </code>
             </example>
@@ -1324,7 +1324,7 @@
                 "ptr_xpkhwpnz2cmegsws737xbsqnmnuwtbm5")
             .WithUserToken("ptu_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a")
             .Build();
-
+            
             var response = await client.Client.Session.Refresh(request);
             </code>
             </example>
@@ -1336,7 +1336,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.ClientToken.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.ClientToken.Check(System.String)">
             <kind>method</kind>
@@ -1358,7 +1358,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Flow.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Flow.Complete(System.String)">
             <kind>method</kind>
@@ -1390,7 +1390,7 @@
                 .WithFlowType(flowType)
                 .WithInvitation("pmc_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a")
                 .Build();
-
+            
             var response = await client.Flow.Start(request);
             </code>
             </example>
@@ -1407,14 +1407,14 @@
             FlowUpdateDataPassword flowUpdateData = new FlowUpdateDataPassword
                 .Builder("hunter2")
                 .Build();
-
+                
             var request = new FlowUpdateRequest
                 .Builder(
-                    "pfl_dxiqyuq7ndc5ycjwdgmguwuodizcaqhh",
-                    FlowChoice.PASSWORD,
+                    "pfl_dxiqyuq7ndc5ycjwdgmguwuodizcaqhh", 
+                    FlowChoice.PASSWORD, 
                     flowUpdateData)
                 .Build();
-
+            
             var response = await client.Flow.Update(request);
             </code>
             </example>
@@ -1429,23 +1429,23 @@
             <example>
             <code>
             var data = new FlowRestartData.Builder().Build();
-
+            
             var request = new FlowRestartRequest
                 .Builder(
-                    "pfl_dxiqyuq7ndc5ycjwdgmguwuodizcaqhh",
-                    FlowChoice.PASSWORD,
+                    "pfl_dxiqyuq7ndc5ycjwdgmguwuodizcaqhh", 
+                    FlowChoice.PASSWORD, 
                     data)
                 .Build();
-
+            
             var response = await client.Flow.Restart(request);
             </code>
             </example>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.Flow.FlowCompleteRequest.FlowID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Flow.FlowCompleteRequest.#ctor(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Clients.Session">
             <kind>class</kind>
@@ -1454,7 +1454,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Session.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.Session.Invalidate(System.String)">
             <kind>method</kind>
@@ -1479,7 +1479,7 @@
             <example>
             <code>
             var request = new SessionListRequest.Builder().Build();
-
+            
             var response = await client.Session.List(request);
             </code>
             </example>
@@ -1504,16 +1504,16 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.User.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.User.Invites">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Clients.User.Authenticators">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.User.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.User.Create(PangeaCyber.Net.AuthN.Requests.UserCreateRequest)">
             <kind>method</kind>
@@ -1527,11 +1527,11 @@
             Profile profile = new Profile();
             profile.FirstName = "Joe";
             profile.LastName = "User";
-
+            
             var request = new UserCreateRequest
                 .Builder("joe.user@pangea.cloud", profile)
                 .Build();
-
+            
             var response = await client.User.Create(request);
             </code>
             </example>
@@ -1576,7 +1576,7 @@
                 .WithEmail("joe.user@pangea.cloud")
                 .WithDisabled(true)
                 .Build();
-
+            
             var response = await client.User.Update(request);
             </code>
             </example>
@@ -1592,12 +1592,12 @@
             <code>
             var request = new UserInviteRequest
                 .Builder(
-                    "admin@pangea.cloud",
-                    "joe.user@pangea.cloud",
-                    "https://www.myserver.com/callback",
+                    "admin@pangea.cloud", 
+                    "joe.user@pangea.cloud", 
+                    "https://www.myserver.com/callback", 
                     "pcb_zurr3lkcwdp5keq73htsfpcii5k4zgm7")
                 .Build();
-
+            
             var response = await client.User.Invite(request);
             </code>
             </example>
@@ -1612,7 +1612,7 @@
             <example>
             <code>
             var request = new UserListRequest.Builder().Build();
-
+            
             var response = await client.User.List(request);
             </code>
             </example>
@@ -1624,7 +1624,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.UserAuthenticators.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.UserAuthenticators.Delete(PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest)">
             <kind>method</kind>
@@ -1639,7 +1639,7 @@
                 .Builder("pau_wuk7tvtpswyjtlsx52b7yyi2l7zotv4a")
                 .WithID("pui_xpkhwpnz2cmegsws737xbsqnmnuwtbm5")
                 .Build();
-
+                
             await client.User.Authenticators.Delete(request);
             </code>
             </example>
@@ -1657,7 +1657,7 @@
                 .Builder()
                 .WithID("pui_xpkhwpnz2cmegsws737xbsqnmnuwtbm5")
                 .Build();
-
+            
             var response = await client.User.Authenticators.List(request);
             </code>
             </example>
@@ -1669,7 +1669,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.UserInvite.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.UserInvite.List(PangeaCyber.Net.AuthN.Requests.UserInviteListRequest)">
             <kind>method</kind>
@@ -1683,7 +1683,7 @@
             var request = new UserInviteListRequest
                 .Builder()
                 .Build();
-
+            
             var response = await client.User.Invites.List(request);
             </code>
             </example>
@@ -1708,7 +1708,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.UserProfile.#ctor(PangeaCyber.Net.AuthN.AuthNClient.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Clients.UserProfile.GetByEmail(System.String)">
             <kind>method</kind>
@@ -1749,70 +1749,70 @@
             {
                 { "country", "Argentina" }
             };
-
+            
             var request = new UserProfileUpdateRequest
                 .Builder(updatedProfile)
                 .WithID("pui_xpkhwpnz2cmegsws737xbsqnmnuwtbm5")
                 .Build();
-
+            
             var response = await client.User.Profile.Update(request);
             </code>
             </example>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.AgreementInfo">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.UpdatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.PublishedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.AgreementInfo.Active">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.AgreementListOrderBy">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.AgreementListOrderBy.ID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.AgreementListOrderBy.CreatedAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.AgreementListOrderBy.Name">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.AgreementListOrderBy.Text">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.AgreementType">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.AgreementType.EULA">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.AgreementType.PrivacyPolicy">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.Authenticator">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Authenticator.Id">
@@ -1852,204 +1852,204 @@
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.DomainIntelligence">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.DomainIntelligence.IsBad">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.DomainIntelligence.Reputation">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FilterAgreementList">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.Active">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.PublishedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterAgreementList.Text">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FilterAgreementList.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FilterSessionList">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.Identity">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.Expire">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterSessionList.Scopes">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FilterSessionList.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FilterUserInviteList">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.Callback">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.InviteOrg">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.Inviter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.State">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.Signup">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.RequireMfa">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.Expire">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.CreatedAt">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FilterUserInviteList.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FilterUserList">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.Disabled">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.RequireMfa">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.Verified">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.Scopes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.EulaId">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.LastLoginIp">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.LastLoginCity">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.LastLoginCountry">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.LastLoginAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FilterUserList.LoginCount">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FilterUserList.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowChoice">
              <summary>
-
+            
              </summary>
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.AGREEMENTS">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.CAPTCHA">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.EMAIL_OTP">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.MAGICLINK">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.PASSWORD">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.PROFILE">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.PROVISIONAL_ENROLLMENT">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.RESET_PASSWORD">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.SET_EMAIL">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.SET_PASSWORD">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.SMS_OTP">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.SOCIAL">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.TOTP">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowChoice.VERIFY_EMAIL">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowChoiceItem">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowChoiceItem.Choice">
@@ -2063,1309 +2063,1309 @@
             </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowRestartData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowRestartData.#ctor(PangeaCyber.Net.AuthN.Models.FlowRestartData.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowRestartData.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowRestartData.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.Phone">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.#ctor(PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.Builder.Phone">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="phone"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowRestartDataSMSOTP.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowType">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowType.Signin">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.FlowType.Signup">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateData.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateData.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateData.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements.Agreed">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements.Builder.Agreed">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements.Builder.#ctor(System.Collections.Generic.List{System.String})">
              <summary>
-
+            
              </summary>
              <param name="agreed"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements.Builder.WithAgreed(System.String)">
              <summary>
-
+            
              </summary>
              <param name="agreed"></param>
              <returns></returns>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataAgreements.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataCaptcha">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataCaptcha.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataCaptcha.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataCaptcha.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataCaptcha.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataCaptcha.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataEmailOTP.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Builder.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Builder.#ctor(System.String,System.String)">
              <summary>
-
+            
              </summary>
              <param name="state"></param>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataMagiclink.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.Password">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.Builder.Password">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="password"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataPassword.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.Profile">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.Builder.Profile">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.Builder.#ctor(PangeaCyber.Net.AuthN.Models.Profile)">
              <summary>
-
+            
              </summary>
              <param name="profile"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProfile.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Builder.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Builder.#ctor(System.String,System.String)">
              <summary>
-
+            
              </summary>
              <param name="state"></param>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataProvisionalEnrollment.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Builder.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Builder.#ctor(System.String,System.String)">
              <summary>
-
+            
              </summary>
              <param name="state"></param>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataResetPassword.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.Email">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.Builder.Email">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="email"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetEmail.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.Password">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.Builder.Password">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="password"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSetPassword.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSMSOTP.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.SocialProvider">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Uri">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Builder.SocialProvider">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Builder.Uri">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Builder.#ctor(System.String,System.String)">
              <summary>
-
+            
              </summary>
              <param name="socialProvider"></param>
              <param name="uri"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataSocialProvider.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.Builder.#ctor(System.String)">
              <summary>
-
+            
              </summary>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataTOTP.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.#ctor(PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Builder)">
              <summary>
-
+            
              </summary>
              <param name="builder"></param>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Builder">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Builder.State">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Builder.Code">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Builder.#ctor(System.String,System.String)">
              <summary>
-
+            
              </summary>
              <param name="state"></param>
              <param name="code"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.FlowUpdateDataVerifyEmail.Builder.Build">
              <summary>
-
+            
              </summary>
              <returns></returns>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.IDProvider">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.IDProvider.Facebook">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.IDProvider.Github">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.IDProvider.Google">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.IDProvider.Microsoft">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.IDProvider.Password">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.IDProviders">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.Intelligence">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Intelligence.Embargo">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Intelligence.IPIntel">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Intelligence.DomainIntel">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Intelligence.UserIntel">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.IPIntelligence">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.IPIntelligence.IsBad">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.IPIntelligence.IsVPN">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.IPIntelligence.IsProxy">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.IPIntelligence.Reputation">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.IPIntelligence.Geolocation">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.ItemOrder">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.ItemOrder.Asc">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.ItemOrder.Desc">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.JWK">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.Alg">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.Kty">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.Kid">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.Use">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.Crv">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.D">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.X">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.Y">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.N">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.JWK.E">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.ListOrder">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.ListOrder.Ascending">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.ListOrder.Descending">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.LoginToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Token">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Life">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Expire">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Identity">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.Scopes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.LoginToken.CreatedAt">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Profile.FirstName">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.Profile.LastName">
              <summary>
-
+            
              </summary>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.Profile.#ctor(System.String,System.String)">
              <summary>
-
+            
              </summary>
              <param name="firstName"></param>
              <param name="lastName"></param>
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Models.Profile.#ctor">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.Scopes">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.SessionItem">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Life">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Expire">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Identity">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Scopes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionItem.ActiveToken">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.SessionOrderBy">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.ID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.CreatetAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.Type">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.Identity">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.Email">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.Expire">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.SessionOrderBy.ActiveTokenID">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.SessionToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Life">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Expire">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Scopes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.SessionToken.Intelligence">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.TOTPsecret">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.TOTPsecret.QrImage">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.TOTPsecret.Secret">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.User">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.ID">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.Email">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.Profile">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.Verified">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.Disabled">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.AcceptedEulaId">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.AcceptedPrivacyPolicyId">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.LastLoginAt">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.CreatedAt">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.LoginCount">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.LastLoginIp">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.LastLoginCity">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.LastLoginCountry">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.User.Authenticators">
              <summary>
-
+            
              </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.UserInvite">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.Inviter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.InviteOrg">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.Callback">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.State">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.RequireMFA">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Models.UserInvite.Expire">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.ID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.CreatedAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.Type">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.Email">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.Expire">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.Callback">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.State">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.Inviter">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy.InviteOrg">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Models.UserListOrderBy">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserListOrderBy.ID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserListOrderBy.CreatedAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserListOrderBy.LastLoginAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.AuthN.Models.UserListOrderBy.Email">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Active">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.Active">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.#ctor(PangeaCyber.Net.AuthN.Models.AgreementType,System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.WithActive(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementCreateRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Id">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Builder.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Builder.Id">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Builder.#ctor(PangeaCyber.Net.AuthN.Models.AgreementType,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementDeleteRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementListRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Size">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.Size">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.WithFilter(System.Collections.Generic.Dictionary{System.String,System.String})">
             @deprecated user WithFilter(FilterAgreementList filter) instead
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.WithFilter(PangeaCyber.Net.AuthN.Models.FilterAgreementList)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.WithLast(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.WithOrder(PangeaCyber.Net.AuthN.Models.ListOrder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.WithOrderBy(PangeaCyber.Net.AuthN.Models.AgreementListOrderBy)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementListRequest.Builder.WithSize(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Id">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Active">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.Id">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.Active">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.#ctor(PangeaCyber.Net.AuthN.Models.AgreementType,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.WithName(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.WithText(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.AgreementUpdateRequest.Builder.WithActive(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.ClientSessionListRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.ClientSessionListRequest.Token">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.ClientSessionListRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.ClientSessionListRequest.Builder.Token">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.ClientSessionListRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.ClientSessionListRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.RefreshToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.UserToken">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.#ctor(PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.Builder.RefreshToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.Builder.UserToken">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.ClientSessionRefreshRequest.Builder.#ctor(System.String)">
             Set the refresh token for the request
@@ -3377,71 +3377,71 @@
             Build the ClientSessionRefreshRequest instance.
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.Size">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.#ctor(PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest{`0}.CommonBuilder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.Size">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.WithFilter(PangeaCyber.Net.Filters.Filter)">
             @deprecated use WithFilter(FilterSessionList filter) instead
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.WithFilter(PangeaCyber.Net.AuthN.Models.FilterSessionList)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.WithLast(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.WithOrder(PangeaCyber.Net.AuthN.Models.ListOrder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.WithOrderBy(PangeaCyber.Net.AuthN.Models.SessionOrderBy)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.CommonSessionListRequest`1.CommonBuilder.WithSize(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.FlowRestartRequest">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowRestartRequest.FlowID">
@@ -3495,56 +3495,56 @@
             </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.FlowStartRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.CBUri">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.FlowType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Invitation">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.CBUri">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.FlowType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.Invitation">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.WithCBUri(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.WithEmail(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.WithFlowType(PangeaCyber.Net.AuthN.Models.FlowType[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.WithInvitation(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.FlowStartRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.FlowUpdateRequest">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.FlowUpdateRequest.FlowID">
@@ -3598,56 +3598,56 @@
             </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.SessionListRequest">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.SessionListRequest.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.SessionListRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.SessionListRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.AuthenticatorID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Email">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.AuthenticatorID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.Email">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.WithID(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.WithEmail(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsDeleteRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsListRequest">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserAuthenticatorsListRequest.ID">
@@ -3691,469 +3691,469 @@
             </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserCreateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Profile">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Builder.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Builder.Profile">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Builder.#ctor(System.String,PangeaCyber.Net.AuthN.Models.Profile)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserCreateRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Size">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.Size">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.WithFilter(PangeaCyber.Net.Filters.Filter)">
             @deprecated use WithFilter(FilterUserInviteList filter) instead
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.WithFilter(PangeaCyber.Net.AuthN.Models.FilterUserInviteList)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.WithLast(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.WithOrder(PangeaCyber.Net.AuthN.Models.ItemOrder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.WithOrderBy(PangeaCyber.Net.AuthN.Models.UserInviteListOrderBy)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.WithSize(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteListRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserInviteRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Inviter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Callback">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.State">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.RequireMFA">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.Inviter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.Callback">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.State">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.RequireMFA">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.#ctor(System.String,System.String,System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.WithRequireMFA(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserInviteRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserListRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Size">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.OrderBy">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.Size">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.WithFilter(PangeaCyber.Net.Filters.Filter)">
             @deprecated use WithFilter(FilterUserList filter) instead
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.WithFilter(PangeaCyber.Net.AuthN.Models.FilterUserList)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.WithLast(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.WithOrder(PangeaCyber.Net.AuthN.Models.ItemOrder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.WithOrderBy(PangeaCyber.Net.AuthN.Models.UserListOrderBy)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.WithSize(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserListRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.#ctor(PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.#ctor(PangeaCyber.Net.AuthN.Models.Profile)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.WithEmail(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.WithID(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserProfileUpdateRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Disabled">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Unlock">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.Disabled">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.Unlock">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.WithId(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.WithEmail(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.WithDisabled(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.WithUnlock(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Requests.UserUpdateRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.AgreementCreateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.AgreementDeleteResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.AgreementListResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.AgreementListResult.Agreements">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.AgreementListResult.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.AgreementListResult.Count">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.AgreementListResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.AgreementUpdateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientJWKSResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientJWKSResult.Keys">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientJWKSResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientPasswordChangeResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientPasswordChangeResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientSessionInvalidateResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientSessionInvalidateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientSessionListResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientSessionListResult.Sessions">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientSessionListResult.Last">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientSessionListResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientSessionLogoutResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientSessionLogoutResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientSessionRefreshResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientSessionRefreshResult.RefreshToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientSessionRefreshResult.ActiveToken">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientSessionRefreshResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Life">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Expire">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Identity">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Scopes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.Profile">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.CreatedAt">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientTokenCheckResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.ClientUserinfoResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientUserinfoResult.RefreshToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.ClientUserinfoResult.ActiveToken">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.ClientUserinfoResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.CommonFlowResult">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.CommonFlowResult.FlowID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.CommonFlowResult.FlowType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.CommonFlowResult.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.CommonFlowResult.Disclaimer">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.CommonFlowResult.FlowPhase">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.CommonFlowResult.FlowChoices">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.FlowCompleteResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.FlowCompleteResult.ActiveToken">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.FlowCompleteResult.RefreshToken">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.FlowCompleteResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.FlowRestartResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.FlowStartResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.FlowUpdateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.SessionInvalidateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.SessionListResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.SessionListResult.Sessions">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.SessionListResult.Last">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.SessionListResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.SessionLogoutResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserAuthenticatorsDeleteResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserAuthenticatorsListResult">
              <summary>
-
+            
              </summary>
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserAuthenticatorsListResult.Authenticators">
@@ -4167,55 +4167,55 @@
             </summary>
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserCreateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserDeleteResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserInviteDeleteResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserInviteListResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserInviteListResult.Invites">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserInviteListResult.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserInviteListResult.Count">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.UserInviteListResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserInviteResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserListResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserListResult.Users">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserListResult.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.AuthN.Results.UserListResult.Count">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.AuthN.Results.UserListResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserProfileGetResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserProfileUpdateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.AuthN.Results.UserUpdateResult">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.BaseClient`1">
             <kind>class</kind>
@@ -4224,88 +4224,88 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.BaseClient`1.config">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.BaseClient`1.serviceName">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.BaseClient`1.ConfigID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.BaseClient`1.PangeaHttpClient">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.BaseClient`1.GeneralHttpClient">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.BaseClient`1.userAgent">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.BaseClient`1.logger">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.BaseClient`1.DefaultPostConfig">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.BaseClient`1.ClientBuilder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.BaseClient`1.ClientBuilder.config">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.BaseClient`1.ClientBuilder.logger">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.ClientBuilder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.ClientBuilder.WithLogger(NLog.Logger)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.#ctor(PangeaCyber.Net.BaseClient{`0}.ClientBuilder,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.SimplePost(System.String,PangeaCyber.Net.BaseRequest,PangeaCyber.Net.FileData)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.DoPost``1(System.String,PangeaCyber.Net.BaseRequest,PangeaCyber.Net.PostConfig)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.RequestPresignedURL(System.String,PangeaCyber.Net.BaseRequest)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.UploadPresignedURL(System.String,PangeaCyber.Net.TransferMethod,PangeaCyber.Net.FileData)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.PollResult``1(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.PollResult(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.Get``1(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.DoGet(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.ParseResponse``1(System.String,System.Net.Http.HttpResponseMessage,PangeaCyber.Net.ResponseHeader)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseClient`1.CheckResponse``1(System.Net.Http.HttpResponseMessage)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.BaseRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.BaseRequest.ConfigID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.BaseRequest.TransferMethod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.BaseRequest.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Config">
             <kind>class</kind>
@@ -4325,25 +4325,25 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Config.Token">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Config.Domain">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Config.ConfigID">
             @deprecated set it on Service builder instead
         </member>
         <member name="P:PangeaCyber.Net.Config.Environment">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Config.Insecure">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Config.ConnectionTimeout">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Config.CustomUserAgent">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Config.QueuedRetryEnabled">
             Enable queued request retry support
@@ -4352,40 +4352,40 @@
             Timeout used to poll results after 202 (in secs)
         </member>
         <member name="M:PangeaCyber.Net.Config.GetServiceUrl(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.LoadEnvironmentVariable(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.GetTestDomain(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.FromEnvironment(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.FromIntegrationEnvironment(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.FromVaultIntegrationEnvironment(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.FromCustomSchemaIntegrationEnvironment(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.GetTestToken(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.GetVaultSignatureTestToken(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.GetMultiConfigTestToken(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.GetCustomSchemaTestToken(PangeaCyber.Net.TestEnvironment)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Config.GetConfigID(PangeaCyber.Net.TestEnvironment,System.String,System.Int32)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Embargo.EmbargoClient">
             <kind>class</kind>
@@ -4394,19 +4394,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Embargo.EmbargoClient.#ctor(PangeaCyber.Net.Embargo.EmbargoClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Embargo.EmbargoClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Embargo.EmbargoClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Embargo.EmbargoClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Embargo.EmbargoClient.ISOCheck(System.String)">
             <kind>method</kind>
@@ -4435,67 +4435,67 @@
             </example>
         </member>
         <member name="T:PangeaCyber.Net.Embargo.EmbargoSanction">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanction.EmbargoedCountryISOCode">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanction.IssuingCountry">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanction.ListName">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanction.EmbargoedCountryName">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanction.Annotations">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Embargo.EmbargoSanctionAnnotation">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanctionAnnotation.Reference">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanctionAnnotation.RestrictionName">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Embargo.EmbargoSanctionAnnotationReference">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanctionAnnotationReference.Paragraph">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanctionAnnotationReference.Regulation">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Embargo.EmbargoSanctions">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanctions.Count">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.EmbargoSanctions.Sanctions">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Embargo.IPCheckRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.IPCheckRequest.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Embargo.IPCheckRequest.#ctor(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Embargo.ISOCheckRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Embargo.ISOCheckRequest.IsoCode">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Embargo.ISOCheckRequest.#ctor(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.ErrorField">
             <kind>class</kind>
@@ -4504,73 +4504,73 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.ErrorField.Code">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ErrorField.Detail">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ErrorField.Source">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ErrorField.Path">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.ErrorField.ToString">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.AcceptedRequestException">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedRequestException.RequestID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedRequestException.AcceptedResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AcceptedRequestException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AcceptedRequestException.Create(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
             This Factory method is needed due to async read of the body
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.AcceptedResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.TTLMins">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.RetryCounter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.Location">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.PostURL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.PutURL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.PostFormData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AcceptedResult.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AcceptedResult.HasUploadURL">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.AcceptedStatus">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedStatus.UploadURL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.AcceptedStatus.UploadDetails">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AcceptedStatus.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.AuditException">
             <kind>class</kind>
@@ -4579,7 +4579,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AuditException.#ctor(System.String,System.Exception)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.ConfigException">
             <kind>class</kind>
@@ -4588,7 +4588,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.ConfigException.#ctor(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.EmbargoIPNotFoundException">
             <kind>class</kind>
@@ -4597,7 +4597,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.EmbargoIPNotFoundException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.InternalServiceErrorException">
             <kind>class</kind>
@@ -4606,7 +4606,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.InternalServiceErrorException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.MissingConfigID">
             <kind>class</kind>
@@ -4615,7 +4615,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.MissingConfigID.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.NoCreditException">
             <kind>class</kind>
@@ -4624,7 +4624,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.NoCreditException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.PangeaAPIException">
             <kind>class</kind>
@@ -4633,13 +4633,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.PangeaAPIException.Response">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.PangeaAPIException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.PangeaAPIException.ToString">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.PangeaException">
             <kind>class</kind>
@@ -4648,10 +4648,10 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.PangeaException.Cause">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.PangeaException.#ctor(System.String,System.Exception)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.ParseResultFailed">
             <kind>class</kind>
@@ -4660,13 +4660,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.ParseResultFailed.Header">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.ParseResultFailed.Body">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.ParseResultFailed.#ctor(System.String,System.Exception,PangeaCyber.Net.ResponseHeader,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.PresignedURLException">
             <kind>class</kind>
@@ -4675,10 +4675,10 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.PresignedURLException.Body">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.PresignedURLException.#ctor(System.String,System.Exception,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.ProviderErrorException">
             <kind>class</kind>
@@ -4687,7 +4687,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.ProviderErrorException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.RateLimitException">
             <kind>class</kind>
@@ -4696,7 +4696,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.RateLimitException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.ServiceNotAvailableException">
             <kind>class</kind>
@@ -4705,7 +4705,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.ServiceNotAvailableException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.ServiceNotEnabledException">
             <kind>class</kind>
@@ -4714,7 +4714,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.ServiceNotEnabledException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.SignerException">
             <kind>class</kind>
@@ -4723,7 +4723,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.SignerException.#ctor(System.String,System.Exception)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.UnauthorizedException">
             <kind>class</kind>
@@ -4732,7 +4732,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.UnauthorizedException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.ValidationException">
             <kind>class</kind>
@@ -4741,7 +4741,7 @@
             </summary>
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.ValidationException.#ctor(System.String,PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.VerificationFailed">
             <kind>class</kind>
@@ -4750,28 +4750,28 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Exceptions.VerificationFailed.Hash">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.VerificationFailed.#ctor(System.String,System.Exception,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileData.File">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileData.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileData.Details">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileData.#ctor(System.IO.FileStream,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileData.#ctor(System.IO.FileStream,System.String,System.Collections.Generic.Dictionary{System.String,System.String})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanClient">
             <kind>class</kind>
@@ -4780,19 +4780,19 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.FileScan.FileScanClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.#ctor(PangeaCyber.Net.FileScan.FileScanClient.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.Scan(PangeaCyber.Net.FileScan.FileScanRequest,System.IO.FileStream)">
              <kind>method</kind>
@@ -4805,39 +4805,39 @@
              <example>
              <code>
              string filepath = "./path/to/file.pdf";
-
+            
              var file = new FileStream(filepath, FileMode.Open, FileAccess.Read);
-
+            
              var request = new FileScanRequest.Builder().WithProvider("crowdstrike").WithRaw(true).WithVerbose(true).Build();
              var response = await client.Scan(request, file, TransferMethod.Direct);
-
+            
              FileScanData data = response.Result.Data;
              </code>
              </example>
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.RequestUploadURL(Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest.Size">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest.Crc32c">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest.Sha256">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest.#ctor(PangeaCyber.Net.FileScan.FileScanRequest,PangeaCyber.Net.FileScan.Models.FileParams)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest.#ctor(PangeaCyber.Net.FileScan.FileScanRequest)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanClient.FileScanFullRequest.#ctor(Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileUploader">
             <kind>class</kind>
@@ -4846,202 +4846,202 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.FileScan.FileUploader.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileUploader.#ctor(PangeaCyber.Net.FileScan.FileUploader.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileUploader.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileUploader.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileUploader.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileUploader.UploadFile(System.String,PangeaCyber.Net.TransferMethod,PangeaCyber.Net.FileData)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanData.Category">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanData.Score">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanData.Verdict">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanData.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.Models.FileParams">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.Models.FileParams.Size">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.Models.FileParams.SHA256">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.Models.FileParams.CRC32C">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.Models.FileParams.#ctor(System.Int32,System.String,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Provider">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Raw">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.SourceURL">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.#ctor(PangeaCyber.Net.FileScan.FileScanRequest.Builder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.#ctor(PangeaCyber.Net.FileScan.FileScanRequest)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.Provider">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.Raw">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.SourceURL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.TransferMethod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithProvider(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithVerbose(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithRaw(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithSourceURL(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithTransferMethod(PangeaCyber.Net.TransferMethod)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.FileScan.FileScanResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanResult.Parameters">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanResult.RawData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Filters.Filter">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Filters.FilterBase">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Filters.FilterBase.Name">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Filters.FilterBase.Map">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterBase.#ctor(System.String,PangeaCyber.Net.Filters.Filter)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Filters.FilterEqual`1">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterEqual`1.#ctor(System.String,PangeaCyber.Net.Filters.Filter)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterEqual`1.Set(`0)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterEqual`1.Get">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Filters.FilterMatch`1">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterMatch`1.#ctor(System.String,PangeaCyber.Net.Filters.Filter)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterMatch`1.GetContains">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterMatch`1.SetContains(System.Collections.Generic.List{`0})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterMatch`1.GetIn">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterMatch`1.SetIn(System.Collections.Generic.List{`0})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Filters.FilterRange`1">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.#ctor(System.String,PangeaCyber.Net.Filters.Filter)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.SetLessThan(`0)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.GetLessThan">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.SetLessThanEqual(`0)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.GetLessThanEqual">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.SetGreaterThan(`0)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.GetGreaterThan">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.SetGreaterThanEqual(`0)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Filters.FilterRange`1.GetGreaterThanEqual">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainIntelClient">
             <kind>class</kind>
@@ -5050,19 +5050,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainIntelClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainIntelClient.#ctor(PangeaCyber.Net.Intel.DomainIntelClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainIntelClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainIntelClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainIntelClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainIntelClient.Reputation(PangeaCyber.Net.Intel.DomainReputationRequest)">
             <kind>method</kind>
@@ -5114,19 +5114,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileIntelClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileIntelClient.#ctor(PangeaCyber.Net.Intel.FileIntelClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileIntelClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileIntelClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileIntelClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileIntelClient.Reputation(PangeaCyber.Net.Intel.FileHashReputationRequest)">
             <kind>method</kind>
@@ -5168,7 +5168,7 @@
             </example>
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileIntelClient.CalculateSHA256fromFile(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPIntelClient">
             <kind>class</kind>
@@ -5177,19 +5177,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPIntelClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPIntelClient.#ctor(PangeaCyber.Net.Intel.IPIntelClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPIntelClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPIntelClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPIntelClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPIntelClient.Geolocate(PangeaCyber.Net.Intel.IPGeolocateRequest)">
             <kind>method</kind>
@@ -5382,937 +5382,937 @@
             </example>
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainWhoIsData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.DomainName">
             <summary>
             Represents information about a domain.
             </summary>
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.DomainAvailability">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.CreatedDate">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.UpdatedDate">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.ExpiresDate">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.HostNames">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.IPs">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.RegistrarName">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.ContactEmail">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.EstimatedDomainAge">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.RegistrantOrganization">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsData.RegistrantCountry">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainWhoIsData.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileReputationBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileReputationData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.HashType">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.HashType.SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.HashType.SHA1">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.HashType.MD5">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.HashType.NTLM">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.HashType.SHA512">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IntelReputationData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelReputationData.Category">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelReputationData.Score">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelReputationData.Verdict">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelReputationData.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainData.DomainFound">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainData.Domain">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.Country">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.City">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.Latitude">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.Longitude">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.PostalCode">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.CountryCode">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyData.IsProxy">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNData.IsVPN">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.PasswordStatus">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.PasswordStatus.Breached">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.PasswordStatus.Unbreached">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Intel.PasswordStatus.Inconclusive">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedData.FoundInBreach">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedData.BreachCount">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedData.FoundInBreach">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedData.BreachCount">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Domains">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder.Domains">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainReputationRequest.Domain">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainReputationRequest.#ctor(PangeaCyber.Net.Intel.DomainReputationRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainReputationRequest.Builder.Domain">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainReputationRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainReputationRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainWhoIsRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsRequest.Domain">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainWhoIsRequest.#ctor(PangeaCyber.Net.Intel.DomainWhoIsRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainWhoIsRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsRequest.Builder.Domain">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainWhoIsRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainWhoIsRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileHashReputationBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Hashes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.HashType">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.Hashes">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.HashType">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.#ctor(System.String[],System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileHashReputationRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationRequest.Hash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationRequest.HashType">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileHashReputationRequest.#ctor(PangeaCyber.Net.Intel.FileHashReputationRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileHashReputationRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationRequest.Builder.Hash">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileHashReputationRequest.Builder.HashType">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileHashReputationRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.FileHashReputationRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IntelCommonRequest`1">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonRequest`1.Provider">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonRequest`1.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonRequest`1.Raw">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.#ctor(`0)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.Provider">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.Raw">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.WithProvider(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.WithVerbose(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.WithRaw(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainBulkRequest.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainBulkRequest.#ctor(PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainRequest.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainRequest.#ctor(PangeaCyber.Net.Intel.IPDomainRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainRequest.Builder.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.#ctor(PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateRequest.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateRequest.#ctor(PangeaCyber.Net.Intel.IPGeolocateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateRequest.Builder.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyBulkRequest.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyBulkRequest.#ctor(PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyRequest.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyRequest.#ctor(PangeaCyber.Net.Intel.IPProxyRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyRequest.Builder.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPReputationBulkRequest.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPReputationRequest.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPReputationRequest.#ctor(PangeaCyber.Net.Intel.IPReputationRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPReputationRequest.Builder.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPReputationRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPReputationRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNBulkRequest.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPVPNBulkRequest.#ctor(PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder.IPs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNRequest.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPVPNRequest.#ctor(PangeaCyber.Net.Intel.IPVPNRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNRequest.Builder.IP">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPVPNRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPVPNRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationBulkRequest.URLs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder.URLs">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.URL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.URLList">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.#ctor(PangeaCyber.Net.Intel.URLReputationRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.Builder.URL">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.Builder.URLList">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.Builder.#ctor(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Emails">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Usernames">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Ips">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.PhoneNumbers">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.End">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.#ctor(PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Emails">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Usernames">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Ips">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.PhoneNumbers">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.End">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithEmails(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithUsernames(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithIPs(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithPhoneNumbers(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithStart(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithEnd(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Username">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Ip">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.PhoneNumber">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.End">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.#ctor(PangeaCyber.Net.Intel.UserBreachedRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.Email">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.Username">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.IP">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.PhoneNumber">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.End">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithEmail(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithUsername(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithIP(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithPhoneNumber(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithStart(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithEnd(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.HashType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.HashPrefixes">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.#ctor(PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.HashType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.HashPrefixes">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.#ctor(PangeaCyber.Net.Intel.HashType,System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.HashType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.HashPrefix">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.#ctor(PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder.HashType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder.HashPrefix">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder.#ctor(PangeaCyber.Net.Intel.HashType,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainReputationBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainReputationResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainWhoIsResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileReputationBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileReputationBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileReputationResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.FileReputationResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IntelCommonResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonResult.Parameters">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IntelCommonResult.RawData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPReputationBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPReputationResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedResult.Data">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLIntelClient">
             <kind>class</kind>
@@ -6321,19 +6321,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLIntelClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLIntelClient.#ctor(PangeaCyber.Net.Intel.URLIntelClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLIntelClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLIntelClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLIntelClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLIntelClient.Reputation(PangeaCyber.Net.Intel.URLReputationRequest)">
             <kind>method</kind>
@@ -6373,19 +6373,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserIntelClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserIntelClient.#ctor(PangeaCyber.Net.Intel.UserIntelClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserIntelClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserIntelClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserIntelClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserIntelClient.Breached(PangeaCyber.Net.Intel.UserBreachedRequest)">
             <kind>method</kind>
@@ -6460,7 +6460,7 @@
             </example>
         </member>
         <member name="M:PangeaCyber.Net.Intel.UserIntelClient.IsPasswordBreached(PangeaCyber.Net.Intel.UserPasswordBreachedResult,System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.PangeaErrors">
             <kind>class</kind>
@@ -6469,7 +6469,7 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.PangeaErrors.Errors">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.PostConfig">
             <kind>class</kind>
@@ -6477,34 +6477,34 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.PostConfig.PollResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.PostConfig.FileData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.PostConfig.#ctor(PangeaCyber.Net.PostConfig.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.PostConfig.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.PostConfig.Builder.PollResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.PostConfig.Builder.FileData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.PostConfig.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.PostConfig.Builder.WithPollResult(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.PostConfig.Builder.WithFileData(PangeaCyber.Net.FileData)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.PostConfig.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactDebugReport">
             <kind>class</kind>
@@ -6513,10 +6513,10 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactDebugReport.SummaryCounts">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactDebugReport.RecognizerResults">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactRecognizerResult">
             <kind>class</kind>
@@ -6525,25 +6525,25 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.FieldType">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.Score">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.Start">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.End">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.Redacted">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactRecognizerResult.DateKey">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactClient">
             <kind>class</kind>
@@ -6552,7 +6552,7 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactClient.#ctor(PangeaCyber.Net.Redact.RedactClient.Builder)">
             Constructor
@@ -6590,16 +6590,16 @@
             </example>
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactClient.Builder">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Redact.RedactClient.Builder.ConfigID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactClient.Builder.WithConfigID(System.String)">
             Add extra public key information
@@ -6611,28 +6611,28 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Data">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Jsonp">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Format">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Debug">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Rules">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Rulesets">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.ReturnResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.#ctor(PangeaCyber.Net.Redact.RedactStructuredRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder">
             <kind>class</kind>
@@ -6641,49 +6641,49 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Data">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Jsonp">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Format">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Debug">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Rules">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Rulesets">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.ReturnResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.#ctor(System.Object)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.WithJsonp(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.WithFormat(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.WithDebug(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.WithRules(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.WithRulesets(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.WithReturnResult(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactStructuredRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactTextRequest">
             <kind>class</kind>
@@ -6692,22 +6692,22 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Debug">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Rules">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Rulesets">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.ReturnResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.#ctor(PangeaCyber.Net.Redact.RedactTextRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactTextRequest.Builder">
             <kind>class</kind>
@@ -6716,37 +6716,37 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Builder.Text">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Builder.Debug">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Builder.Rules">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Builder.Rulesets">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextRequest.Builder.ReturnResult">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.Builder.WithDebug(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.Builder.WithRules(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.Builder.WithRulesets(System.String[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.Builder.WithReturnResult(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Redact.RedactTextRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactStructuredResult">
             <kind>class</kind>
@@ -6755,13 +6755,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredResult.Count">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredResult.Report">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactStructuredResult.RedactedData">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Redact.RedactTextResult">
             <kind>class</kind>
@@ -6770,13 +6770,13 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextResult.Count">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextResult.Report">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Redact.RedactTextResult.RedactedText">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Response`1">
             <kind>class</kind>
@@ -6785,19 +6785,19 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.Response`1.Result">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Response`1.AcceptedResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Response`1.HttpResponse">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Response`1.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Response`1.#ctor(PangeaCyber.Net.Response{PangeaCyber.Net.PangeaErrors},PangeaCyber.Net.Exceptions.AcceptedResult)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.ResponseHeader">
             <kind>class</kind>
@@ -6806,28 +6806,28 @@
             </summary>
         </member>
         <member name="P:PangeaCyber.Net.ResponseHeader.RequestId">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ResponseHeader.RequestTime">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ResponseHeader.ResponseTime">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ResponseHeader.Status">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ResponseHeader.Summary">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.ResponseHeader.IsOK">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.ResponseHeader.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.ResponseHeader.#ctor(PangeaCyber.Net.ResponseHeader)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.ResponseStatus">
             <kind>enum</kind>
@@ -6836,46 +6836,46 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.Success">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.Failed">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.ValidationError">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.TooManyRequests">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.NoCredit">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.Unauthorized">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.ServiceNotEnabled">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.ProviderError">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.MissingConfigID">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.MissingConfigIDScope">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.ServiceNotAvailable">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.TreeNotFound">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.IPNotFound">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.ResponseStatus.Accepted">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.TestEnvironment">
             <kind>enum</kind>
@@ -6884,1781 +6884,1781 @@
             </summary>
         </member>
         <member name="F:PangeaCyber.Net.TestEnvironment.LVE">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.TestEnvironment.DEV">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.TestEnvironment.STG">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.TransferMethod">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.TransferMethod.Multipart">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.TransferMethod.PostURL">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.TransferMethod.PutURL">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.TransferMethod.SourceURL">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.OrderedContractResolver">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.OrderedContractResolver.CreateProperties(System.Type,Newtonsoft.Json.MemberSerialization)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Utils">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.StringToStringB64(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.Base64ToString(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.Bytes2Hex(System.Byte[])">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetSHA256Hash(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetSHA1Hash(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetSHA512Hash(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetSHA256HashFromFilepath(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetSHA1HashFromFilepath(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetHashPrefix(System.String,System.Int32)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetBytes(System.UInt32)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Utils.GetUploadFileParams(System.IO.FileStream)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.ED25519">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.ES256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.ES384">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.ES512">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA2048_PKCS1V15_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA2048_OAEP_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.ES256K">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA2048_OAEP_SHA1">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA2048_OAEP_SHA512">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA3072_OAEP_SHA1">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA3072_OAEP_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA3072_OAEP_SHA512">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA4096_OAEP_SHA1">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA4096_OAEP_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA4096_OAEP_SHA512">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA2048_PSS_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA3072_PSS_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA4096_PSS_SHA256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm.RSA4096_PSS_SHA512">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.InheritedSettings">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.InheritedSettings.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.InheritedSettings.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.InheritedSettings.RotationGracePeriod">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ItemData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.CurrentVersion">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.LastRotated">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.NextRotation">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Expiration">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemData.Purpose">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ItemOrder">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrder.Asc">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrder.Desc">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ItemOrderBy">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.Type">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.CreatedAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.DestroyAt">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.Purpose">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.Expiration">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.LastRotated">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.NextRotation">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.Name">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.Folder">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemOrderBy.Version">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ItemType">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemType.AsymmetricKey">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemType.SymmetricKey">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemType.Secret">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ItemVersionData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemVersionData.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemVersionData.State">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemVersionData.CreatedAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemVersionData.DestroyAt">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemVersionData.Secret">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ItemVersionData.EncodedPublicKey">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ItemVersionState">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemVersionState.Active">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemVersionState.Deactivated">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemVersionState.Suspended">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemVersionState.Compromised">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.ItemVersionState.Destroyed">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.JWK">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.Alg">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.Kty">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.Kid">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.Use">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.Crv">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.D">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.X">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.Y">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.N">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.JWK.E">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.KeyPurpose">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.KeyPurpose.Signing">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.KeyPurpose.Encryption">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.KeyPurpose.JWT">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.ListItemData">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Models.ListItemData.CompromisedVersions">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.Metadata">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.SecretAlgorithm">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SecretAlgorithm.Base32">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm.HS256">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm.HS384">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm.HS512">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm.AES128_CFB">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm.AES256_CFB">
-
+            
         </member>
         <member name="F:PangeaCyber.Net.Vault.Models.SymmetricAlgorithm.AES256_GCM">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Models.Tags">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.#ctor(PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder.#ctor(PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm,PangeaCyber.Net.Vault.Models.KeyPurpose,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder.WithAlgorithm(PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricGenerateRequest.Builder.WithPurpose(PangeaCyber.Net.Vault.Models.KeyPurpose)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Purpose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.EncodedPublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.EncodedPrivateKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.#ctor(PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.Purpose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.EncodedPublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.EncodedPrivateKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.#ctor(System.String,System.String,PangeaCyber.Net.Vault.Models.AsymmetricAlgorithm,PangeaCyber.Net.Vault.Models.KeyPurpose,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.AsymmetricStoreRequest.Builder.WithPurpose(PangeaCyber.Net.Vault.Models.KeyPurpose)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.Expiration">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.#ctor(`0)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.AutoRotate">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.Expiration">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithName(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithFolder(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithMetadata(PangeaCyber.Net.Vault.Models.Metadata)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithTags(PangeaCyber.Net.Vault.Models.Tags)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithAutoRotate(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithRotationFrequency(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithRotationState(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonGenerateRequest`1.CommonBuilder.WithExpiration(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.RotationFrequency">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.#ctor(PangeaCyber.Net.Vault.Requests.CommonRotateRequest{`0}.CommonBuilder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.RotationFrequency">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.WithRotationState(PangeaCyber.Net.Vault.Models.ItemVersionState)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonRotateRequest`1.CommonBuilder.WithRotationFrequency(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.Expiration">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.#ctor(`0)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.AutoRotate">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.Expiration">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithFolder(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithMetadata(PangeaCyber.Net.Vault.Models.Metadata)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithTags(PangeaCyber.Net.Vault.Models.Tags)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithAutoRotate(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithRotationFrequency(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithRotationState(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.CommonStoreRequest`1.CommonBuilder.WithExpiration(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.DecryptRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.CipherText">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.AdditionalData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DecryptRequest.#ctor(PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.CipherText">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.AdditionalData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.WithVersion(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DecryptRequest.Builder.WithAdditionalData(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.DeleteRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DeleteRequest.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DeleteRequest.#ctor(PangeaCyber.Net.Vault.Requests.DeleteRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.DeleteRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.DeleteRequest.Builder.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DeleteRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.DeleteRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.EncryptRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.PlainText">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.AdditionalData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.EncryptRequest.#ctor(PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.PlainText">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.AdditionalData">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.WithVersion(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.EncryptRequest.Builder.WithAdditionalData(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.FolderCreateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.#ctor(PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.WithMetadata(PangeaCyber.Net.Vault.Models.Metadata)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.WithTags(PangeaCyber.Net.Vault.Models.Tags)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.WithRotationFrequency(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.WithRotationState(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.FolderCreateRequest.Builder.WithRotationGracePeriod(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.GetRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.VersionState">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.GetRequest.#ctor(PangeaCyber.Net.Vault.Requests.GetRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.GetRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.Verbose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.VersionState">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.WithVersion(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.WithVerbose(System.Boolean)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.GetRequest.Builder.WithVersionState(PangeaCyber.Net.Vault.Models.ItemVersionState)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.JWKGetRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWKGetRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWKGetRequest.#ctor(PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder.WithVersion(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWKGetRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.JWTSignRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWTSignRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWTSignRequest.Payload">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWTSignRequest.#ctor(PangeaCyber.Net.Vault.Requests.JWTSignRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.JWTSignRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWTSignRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWTSignRequest.Builder.Payload">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWTSignRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWTSignRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.JWS">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.#ctor(PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.Builder.JWS">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.JWTVerifyRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.KeyRotateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.EncodedPublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.EncodedPrivateKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.EncodedSymmetricKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.#ctor(PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.EncodedPublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.EncodedPrivateKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.EncodedSymmetricKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.#ctor(System.String,PangeaCyber.Net.Vault.Models.ItemVersionState)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.WithEncodedPublicKey(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.WithEncodedPrivateKey(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.KeyRotateRequest.Builder.WithEncodedSymmetricKey(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.ListRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Size">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.OrderBy">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.#ctor(PangeaCyber.Net.Vault.Requests.ListRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.ListRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.Filter">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.Last">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.Size">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.Order">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.OrderBy">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.WithFilter(System.Collections.Generic.Dictionary{System.String,System.String})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.WithLast(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.WithSize(System.Int32)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.WithOrder(PangeaCyber.Net.Vault.Models.ItemOrder)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.ListRequest.Builder.WithOrderBy(PangeaCyber.Net.Vault.Models.ItemOrderBy)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.#ctor(PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.Builder.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenRotateRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Token">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.#ctor(PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder.Token">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.PangeaTokenStoreRequest.Builder.WithRotationGracePeriod(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SecretRotateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Secret">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.#ctor(PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Builder.Secret">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretRotateRequest.Builder.WithSecret(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SecretStoreRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Secret">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Type">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.#ctor(PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Builder.Secret">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SecretStoreRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SignRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SignRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SignRequest.Message">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SignRequest.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SignRequest.#ctor(PangeaCyber.Net.Vault.Requests.SignRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SignRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SignRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SignRequest.Builder.Message">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SignRequest.Builder.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SignRequest.Builder.#ctor(System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SignRequest.Builder.WithVersion(System.Nullable{System.Int32})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SignRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.StateChangeRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.StateChangeRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.StateChangeRequest.State">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.StateChangeRequest.#ctor(PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder.State">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder.#ctor(System.String,System.Int32,PangeaCyber.Net.Vault.Models.ItemVersionState)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.StateChangeRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.#ctor(PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder.#ctor(PangeaCyber.Net.Vault.Models.SymmetricAlgorithm,PangeaCyber.Net.Vault.Models.KeyPurpose,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder.WithAlgorithm(PangeaCyber.Net.Vault.Models.SymmetricAlgorithm)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricGenerateRequest.Builder.WithPurpose(PangeaCyber.Net.Vault.Models.KeyPurpose)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.EncodedSymmetricKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.#ctor(PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder.EncodedSymmetricKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder.#ctor(System.String,PangeaCyber.Net.Vault.Models.SymmetricAlgorithm,PangeaCyber.Net.Vault.Models.KeyPurpose,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.SymmetricStoreRequest.Builder.WithPurpose(PangeaCyber.Net.Vault.Models.KeyPurpose)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.UpdateRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.RotationGracePeriod">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Expiration">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.#ctor(PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.Name">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.Folder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.Metadata">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.Tags">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.AutoRotate">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.RotationFrequency">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.RotationState">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.Expiration">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.RotationGracePeriod">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.#ctor(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithName(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithFolder(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithMetadata(PangeaCyber.Net.Vault.Models.Metadata)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithTags(PangeaCyber.Net.Vault.Models.Tags)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithAutoRotate(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithRotationFrequency(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithRotationState(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithExpiration(System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.UpdateRequest.Builder.WithRotationGracePeriod(System.String)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.VerifyRequest">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Message">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Signature">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.VerifyRequest.#ctor(PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder)">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.Message">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.Signature">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.#ctor(System.String,System.String,System.String)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.WithVersion(System.Int32)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Requests.VerifyRequest.Builder.Build">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.AsymmetricGenerateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.AsymmetricGenerateResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.AsymmetricGenerateResult.Purpose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.AsymmetricGenerateResult.EncodedPublicKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.AsymmetricGenerateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.AsymmetricStoreResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.AsymmetricStoreResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.AsymmetricStoreResult.Purpose">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.AsymmetricStoreResult.EncodedPublicKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.AsymmetricStoreResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.CommonGenerateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonGenerateResult.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonGenerateResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonGenerateResult.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.CommonGenerateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.CommonRotateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonRotateResult.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonRotateResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonRotateResult.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.CommonRotateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.CommonStoreResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonStoreResult.Type">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonStoreResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.CommonStoreResult.Version">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.CommonStoreResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.DecryptResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.DecryptResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.DecryptResult.PlainText">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.DecryptResult.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.DecryptResult.Algorithm">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.DecryptResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.DeleteResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.DeleteResult.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.DeleteResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.EncryptResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.EncryptResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.EncryptResult.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.EncryptResult.CipherText">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.EncryptResult.Algorithm">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.EncryptResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.FolderCreateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.FolderCreateResult.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.FolderCreateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.GetResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.GetResult.Versions">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.GetResult.RotationGracePeriod">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.GetResult.InheritedSettings">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.GetResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.JWKGetResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.JWKGetResult.Keys">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.JWKGetResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.JWTSignResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.JWTSignResult.JWS">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.JWTSignResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.JWTVerifyResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.JWTVerifyResult.ValidSignature">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.JWTVerifyResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.KeyRotateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.KeyRotateResult.EncodedPublicKey">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.KeyRotateResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.KeyRotateResult.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.KeyRotateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.ListResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.ListResult.Items">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.ListResult.Count">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.ListResult.Last">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.ListResult.#ctor">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.ListResult.GetItems">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.SecretRotateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SecretRotateResult.Secret">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.SecretRotateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.SecretStoreResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SecretStoreResult.Secret">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.SecretStoreResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.SignResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SignResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SignResult.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SignResult.Signature">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SignResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SignResult.EncodedPublicKey">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.SignResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.StateChangeResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.StateChangeResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.StateChangeResult.State">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.StateChangeResult.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.StateChangeResult.DestroyAt">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.StateChangeResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.SymmetricGenerateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SymmetricGenerateResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SymmetricGenerateResult.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.SymmetricGenerateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.SymmetricStoreResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SymmetricStoreResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.SymmetricStoreResult.Purpose">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.SymmetricStoreResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.UpdateResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.UpdateResult.ID">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.UpdateResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.Results.VerifyResult">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.VerifyResult.ID">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.VerifyResult.Version">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.VerifyResult.Algorithm">
-
+            
         </member>
         <member name="P:PangeaCyber.Net.Vault.Results.VerifyResult.ValidSignature">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.Results.VerifyResult.#ctor">
-
+            
         </member>
         <member name="T:PangeaCyber.Net.Vault.VaultClient">
             <kind>class</kind>
             <summary>Vault Client</summary>
         </member>
         <member name="P:PangeaCyber.Net.Vault.VaultClient.ServiceName">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.VaultClient.#ctor(PangeaCyber.Net.Vault.VaultClient.Builder)">
             Constructor
         </member>
         <member name="T:PangeaCyber.Net.Vault.VaultClient.Builder">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.VaultClient.Builder.#ctor(PangeaCyber.Net.Config)">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.VaultClient.Builder.Build">
-
+            
         </member>
         <member name="M:PangeaCyber.Net.Vault.VaultClient.StateChange(System.String,System.Int32,PangeaCyber.Net.Vault.Models.ItemVersionState)">
             <kind>method</kind>
@@ -8809,7 +8809,7 @@
             <example>
             <code>
             var request = new SecretRotateRequest.Builder(
-                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5",
+                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5", 
                     "12sdfgs4543qv@#%$casd")
                 .WithRotationState(ItemVersionState.Deactivated)
                 .Build();
@@ -8852,8 +8852,8 @@
             <code>
             SymmetricGenerateRequest request = new SymmetricGenerateRequest
                 .Builder(
-                    SymmetricAlgorithm.AES128_CFB,
-                    KeyPurpose.Encryption,
+                    SymmetricAlgorithm.AES128_CFB, 
+                    KeyPurpose.Encryption, 
                     "my-very-secret-secret")
                 .Build();
             var response = await client.SymmetricGenerate(request);
@@ -8875,8 +8875,8 @@
             <code>
             AsymmetricGenerateRequest request = new AsymmetricGenerateRequest
                 .Builder(
-                    AsymmetricAlgorithm.ED25519,
-                    KeyPurpose.Signing,
+                    AsymmetricAlgorithm.ED25519, 
+                    KeyPurpose.Signing, 
                     "my-very-secret-secret")
                 .Build();
             var response = await client.AsymmetricGenerate(request);
@@ -8898,10 +8898,10 @@
             <code>
             AsymmetricStoreRequest request = new AsymmetricStoreRequest
                 .Builder(
-                    "encoded private key",
-                    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA8s5JopbEPGBylPBcMK+L5PqHMqPJW/5KYPgBHzZGncc=\n-----END PUBLIC KEY-----",
-                    AsymmetricAlgorithm.RSA4096_OAEP_SHA256,
-                    KeyPurpose.Signing,
+                    "encoded private key", 
+                    "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA8s5JopbEPGBylPBcMK+L5PqHMqPJW/5KYPgBHzZGncc=\n-----END PUBLIC KEY-----", 
+                    AsymmetricAlgorithm.RSA4096_OAEP_SHA256, 
+                    KeyPurpose.Signing, 
                     "my-very-secret-secret")
                 .Build();
             var response = await client.AsymmetricStore(request);
@@ -8923,9 +8923,9 @@
             <code>
             SymmetricStoreRequest request = new SymmetricStoreRequest
                 .Builder(
-                    "lJkk0gCLux+Q+rPNqLPEYw==",
-                    SymmetricAlgorithm.AES128_CFB,
-                    KeyPurpose.Encryption,
+                    "lJkk0gCLux+Q+rPNqLPEYw==", 
+                    SymmetricAlgorithm.AES128_CFB, 
+                    KeyPurpose.Encryption, 
                     "my-very-secret-secret")
                 .Build();
             var response = await client.SymmetricStore(request);
@@ -8947,7 +8947,7 @@
             <code>
             KeyRotateRequest request = new KeyRotateRequest
                 .Builder(
-                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5",
+                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5", 
                     ItemVersionState.Deactivated)
                 .WithEncodedSymmetricKey("lJkk0gCLux+Q+rPNqLPEYw==")
                 .Build();
@@ -8970,7 +8970,7 @@
             <code>
             EncryptRequest request = new EncryptRequest
                 .Builder(
-                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5",
+                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5", 
                     "lJkk0gCLux+Q+rPNqLPEYw==")
                 .WithVersion(2)
                 .Build();
@@ -8993,7 +8993,7 @@
             <code>
             DecryptRequest request = new DecryptRequest
                 .Builder(
-                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5",
+                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5", 
                     "lJkk0gCLux+Q+rPNqLPEYw==")
                 .WithVersion(2)
                 .Build();
@@ -9016,7 +9016,7 @@
             <code>
             SignRequest request = new SignRequest
                 .Builder(
-                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5",
+                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5", 
                     "lJkk0gCLux+Q+rPNqLPEYw==")
                 .Build();
             var response = await client.Sign(request);
@@ -9058,8 +9058,8 @@
             <code>
             var request = new VerifyRequest
                 .Builder(
-                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5",
-                    "data2verify",
+                    "pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5", 
+                    "data2verify", 
                     "signature")
                 .Build();
             var response = await client.Verify(request);
@@ -9122,7 +9122,7 @@
             <code>
             var request = new FolderCreateRequest
                 .Builder(
-                    "folder_name",
+                    "folder_name", 
                     "parent/folder/name")
                 .Build();
             var response = await client.FolderCreate(request);
@@ -9130,61 +9130,61 @@
             </example>
         </member>
         <member name="T:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Provider">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Verbose">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Raw">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.TransferMethod">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.FileParams">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.#ctor(Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder)">
-
+            
         </member>
         <member name="T:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.Provider">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.Verbose">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.Raw">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.TransferMethod">
-
+            
         </member>
         <member name="P:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.FileParams">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.Build">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.WithProvider(System.String)">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.WithVerbose(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.WithRaw(System.Nullable{System.Boolean})">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.WithTransferMethod(PangeaCyber.Net.TransferMethod)">
-
+            
         </member>
         <member name="M:Cloud.PangeaCyber.Pangea.FileScan.Requests.FileScanUploadURLRequest.Builder.WithFileParams(PangeaCyber.Net.FileScan.Models.FileParams)">
-
+            
         </member>
     </members>
 </doc>

--- a/packages/pangea-sdk/docsgen/source/PangeaCyber.Net.xml
+++ b/packages/pangea-sdk/docsgen/source/PangeaCyber.Net.xml
@@ -140,72 +140,72 @@
             Constructor
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.Log(PangeaCyber.Net.Audit.IEvent,PangeaCyber.Net.Audit.LogConfig)">
-            <kind>method</kind>
-            <summary>
-            Log an event to Audit Secure Log. By default does not sign event and verbose is left as server default
-            </summary>
-            <remarks>Log an entry</remarks>
-            <operationid>audit_post_v1_log</operationid>
-            <param name="evt" type="PangeaCyber.Net.Audit.IEvent">Event to log</param>
-            <param name="config" type="PangeaCyber.Net.Audit.LogConfig">Include verbosity, local signature and verify events setup</param>
-            <returns>Response&lt;LogResult&gt;</returns>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
-            <example>
-            <code>
-            string msg = "hello world";
-            var event = new StandardEvent.Builder(msg)
-                .Build();
+             <kind>method</kind>
+             <summary>
+             Log an event to Audit Secure Log. By default does not sign event and verbose is left as server default
+             </summary>
+             <remarks>Log an entry</remarks>
+             <operationid>audit_post_v1_log</operationid>
+             <param name="evt" type="PangeaCyber.Net.Audit.IEvent">Event to log</param>
+             <param name="config" type="PangeaCyber.Net.Audit.LogConfig">Include verbosity, local signature and verify events setup</param>
+             <returns>Response&lt;LogResult&gt;</returns>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
+             <example>
+             <code>
+             string msg = "hello world";
+             var event = new StandardEvent.Builder(msg)
+                 .Build();
             
-            var config = new LogConfig.Builder()
-                .WithVerbose(true)
-                .Build();
+             var config = new LogConfig.Builder()
+                 .WithVerbose(true)
+                 .Build();
             
-            var response = await client.Log(event, config);
-            </code>
-            </example>
+             var response = await client.Log(event, config);
+             </code>
+             </example>
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.LogBulk(PangeaCyber.Net.Audit.IEvent[],PangeaCyber.Net.Audit.LogConfig)">
-            <kind>method</kind>
-            <summary>
-            Create multiple log entries in the Secure Audit Log.
-            </summary>
-            <remarks>Log multiple entries</remarks>
-            <operationid>audit_post_v2_log</operationid>
-            <param name="events" type="PangeaCyber.Net.Audit.IEvent[]">Events to log</param>
-            <param name="config" type="PangeaCyber.Net.Audit.LogConfig">Include verbosity, local signature and verify events setup</param>
-            <returns>Response&lt;LogBulkResult&gt;</returns>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
-            <example>
-            <code>
-            var event = new StandardEvent.Builder("hello world").Build();
-            StandardEvent[] events = {event};
+             <kind>method</kind>
+             <summary>
+             Create multiple log entries in the Secure Audit Log.
+             </summary>
+             <remarks>Log multiple entries</remarks>
+             <operationid>audit_post_v2_log</operationid>
+             <param name="events" type="PangeaCyber.Net.Audit.IEvent[]">Events to log</param>
+             <param name="config" type="PangeaCyber.Net.Audit.LogConfig">Include verbosity, local signature and verify events setup</param>
+             <returns>Response&lt;LogBulkResult&gt;</returns>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
+             <example>
+             <code>
+             var event = new StandardEvent.Builder("hello world").Build();
+             StandardEvent[] events = {event};
             
-            var response = await client.LogBulk(events, new LogConfig.Builder().Build());
-            </code>
-            </example>
+             var response = await client.LogBulk(events, new LogConfig.Builder().Build());
+             </code>
+             </example>
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.LogBulkAsync(PangeaCyber.Net.Audit.IEvent[],PangeaCyber.Net.Audit.LogConfig)">
-            <kind>method</kind>
-            <summary>
-            Asynchronously create multiple log entries in the Secure Audit Log.
-            </summary>
-            <remarks>Log multiple entries asynchronously</remarks>
-            <operationid>audit_post_v2_log_async</operationid>
-            <param name="events" type="PangeaCyber.Net.Audit.IEvent[]"></param>
-            <param name="config" type="PangeaCyber.Net.Audit.LogConfig"></param>
-            <returns>Response&lt;LogBulkResult&gt;</returns>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
-            <example>
-            <code>
-            var event = new StandardEvent.Builder("hello world").Build();
-            StandardEvent[] events = {event};
+             <kind>method</kind>
+             <summary>
+             Asynchronously create multiple log entries in the Secure Audit Log.
+             </summary>
+             <remarks>Log multiple entries asynchronously</remarks>
+             <operationid>audit_post_v2_log_async</operationid>
+             <param name="events" type="PangeaCyber.Net.Audit.IEvent[]"></param>
+             <param name="config" type="PangeaCyber.Net.Audit.LogConfig"></param>
+             <returns>Response&lt;LogBulkResult&gt;</returns>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
+             <example>
+             <code>
+             var event = new StandardEvent.Builder("hello world").Build();
+             StandardEvent[] events = {event};
             
-            var response = await client.LogBulkAsync(events, new LogConfig.Builder().Build());
-            </code>
-            </example>
+             var response = await client.LogBulkAsync(events, new LogConfig.Builder().Build());
+             </code>
+             </example>
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.GetRoot">
             <kind>method</kind>
@@ -236,50 +236,50 @@
             </example>
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.Search(PangeaCyber.Net.Audit.SearchRequest,PangeaCyber.Net.Audit.SearchConfig)">
-            <kind>method</kind>
-            <summary>Perform a search of logs according to input param. By default verify logs consistency and events hash and signature.</summary>
-            <remarks>Search</remarks>
-            <operationid>audit_post_v1_search</operationid>
-            <param name="request" type="PangeaCyber.Net.Audit.SearchRequest">Request to be sent to /search endpoint</param>
-            <param name="config" type="PangeaCyber.Net.Audit.SearchConfig">Config include event and consistency verification setup</param>
-            <returns>Response&lt;SearchOutput&gt;</returns>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
-            <example>
-            <code>
-            var request = new SearchRequest
-                .Builder("message:hello world")
-                .Build();
-            var config = new SearchConfig
-                .Builder()
-                .Build();
+             <kind>method</kind>
+             <summary>Perform a search of logs according to input param. By default verify logs consistency and events hash and signature.</summary>
+             <remarks>Search</remarks>
+             <operationid>audit_post_v1_search</operationid>
+             <param name="request" type="PangeaCyber.Net.Audit.SearchRequest">Request to be sent to /search endpoint</param>
+             <param name="config" type="PangeaCyber.Net.Audit.SearchConfig">Config include event and consistency verification setup</param>
+             <returns>Response&lt;SearchOutput&gt;</returns>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
+             <example>
+             <code>
+             var request = new SearchRequest
+                 .Builder("message:hello world")
+                 .Build();
+             var config = new SearchConfig
+                 .Builder()
+                 .Build();
             
-            var response = await client.Search(request, config);
-            </code>
-            </example>
+             var response = await client.Search(request, config);
+             </code>
+             </example>
         </member>
         <member name="M:PangeaCyber.Net.Audit.AuditClient.Results(PangeaCyber.Net.Audit.ResultRequest,PangeaCyber.Net.Audit.SearchConfig)">
-            <kind>method</kind>
-            <summary>Return result's page from search id.</summary>
-            <remarks>Results</remarks>
-            <operationid>audit_post_v1_results</operationid>
-            <param name="request" type="PangeaCyber.Net.Audit.ResultRequest">Request to be sent to /results endpoint</param>
-            <param name="config" type="PangeaCyber.Net.Audit.SearchConfig">Config include event and consistency verification setup</param>
-            <returns>Response&lt;ResultsOutput&gt;</returns>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
-            <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
-            <example>
-            <code>
-            var request = new ResultRequest
-                .Builder("pas_sqilrhruwu54uggihqj3aie24wrctakr")
-                .Build();
-            var config = new SearchConfig
-                .Builder()
-                .Build();
+             <kind>method</kind>
+             <summary>Return result's page from search id.</summary>
+             <remarks>Results</remarks>
+             <operationid>audit_post_v1_results</operationid>
+             <param name="request" type="PangeaCyber.Net.Audit.ResultRequest">Request to be sent to /results endpoint</param>
+             <param name="config" type="PangeaCyber.Net.Audit.SearchConfig">Config include event and consistency verification setup</param>
+             <returns>Response&lt;ResultsOutput&gt;</returns>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaException"></exception>
+             <exception cref="T:PangeaCyber.Net.Exceptions.PangeaAPIException"></exception>
+             <example>
+             <code>
+             var request = new ResultRequest
+                 .Builder("pas_sqilrhruwu54uggihqj3aie24wrctakr")
+                 .Build();
+             var config = new SearchConfig
+                 .Builder()
+                 .Build();
             
-            var response = await client.Results(request, config);
-            </code>
-            </example>
+             var response = await client.Results(request, config);
+             </code>
+             </example>
         </member>
         <member name="T:PangeaCyber.Net.Audit.AuditClient.Builder">
             <kind>class</kind>
@@ -1269,7 +1269,7 @@
             <kind>method</kind>
             <summary>Invalidate a session by session ID using a client token.</summary>
             <remarks>Invalidate Session | Client</remarks>
-            <operationid>authn_post_v2_client_password_change</operationid>
+            <operationid>authn_post_v2_client_session_invalidate</operationid>
             <param name="token" type="string">A user token value</param>
             <param name="sessionID" type="string">An ID for a token</param>
             <returns>Response&lt;ClientSessionInvalidateResult&gt;</returns>
@@ -4536,10 +4536,28 @@
         <member name="T:PangeaCyber.Net.Exceptions.AcceptedResult">
             
         </member>
-        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.AcceptedStatus">
+        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.TTLMins">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.RetryCounter">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.Location">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.PostURL">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.PutURL">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Exceptions.AcceptedResult.PostFormData">
             
         </member>
         <member name="M:PangeaCyber.Net.Exceptions.AcceptedResult.#ctor">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Exceptions.AcceptedResult.HasUploadURL">
             
         </member>
         <member name="T:PangeaCyber.Net.Exceptions.AcceptedStatus">
@@ -4887,6 +4905,9 @@
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Raw">
             
         </member>
+        <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.SourceURL">
+            
+        </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.#ctor(PangeaCyber.Net.FileScan.FileScanRequest.Builder)">
             
         </member>
@@ -4908,6 +4929,9 @@
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.Raw">
             
         </member>
+        <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.SourceURL">
+            
+        </member>
         <member name="P:PangeaCyber.Net.FileScan.FileScanRequest.Builder.TransferMethod">
             
         </member>
@@ -4924,6 +4948,9 @@
             
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithRaw(System.Nullable{System.Boolean})">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithSourceURL(System.String)">
             
         </member>
         <member name="M:PangeaCyber.Net.FileScan.FileScanRequest.Builder.WithTransferMethod(PangeaCyber.Net.TransferMethod)">
@@ -5051,6 +5078,21 @@
             </code>
             </example>
         </member>
+        <member name="M:PangeaCyber.Net.Intel.DomainIntelClient.ReputationBulk(PangeaCyber.Net.Intel.DomainReputationBulkRequest)">
+            <kind>method</kind>
+            <summary>Retrieve reputations for a list of domains, from a provider, including an optional detailed report.</summary>
+            <remarks>Reputation V2</remarks>
+            <operationid>domain_intel_post_v2_reputation</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.DomainReputationBulkRequest">DomainReputationBulkRequest with a domain list and provider</param>
+            <returns>Response&lt;DomainReputationBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] domains = new string[1] {"737updatesboeing.com"};
+            var request = new DomainReputationBulkRequest.Builder(domains).Build();
+            var response = await client.ReputationBulk(request);
+            </code>
+            </example>
+        </member>
         <member name="M:PangeaCyber.Net.Intel.DomainIntelClient.WhoIs(PangeaCyber.Net.Intel.DomainWhoIsRequest)">
             <kind>method</kind>
             <summary>Retrieve who is for a domain from a provider, including an optional detailed report.</summary>
@@ -5106,6 +5148,25 @@
             </code>
             </example>
         </member>
+        <member name="M:PangeaCyber.Net.Intel.FileIntelClient.ReputationBulk(PangeaCyber.Net.Intel.FileHashReputationBulkRequest)">
+            <kind>method</kind>
+            <summary>Retrieve reputation scores for a list of file hashes, from a provider, including an optional detailed report.</summary>
+            <remarks>Reputation V2</remarks>
+            <operationid>file_intel_post_v2_reputation</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.FileHashReputationBulkRequest">FileHashReputationBulkRequest with the hash file list to be looked up</param>
+            <returns>Response&lt;FileReputationBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] hashes = new string[1] {"142b638c6a60b60c7f9928da4fb85a5a8e1422a9ffdc9ee49e17e56ccca9cf6e"};
+            var request = new FileHashReputationBulkRequest.Builder(hashes, "sha256")
+                .WithProvider("reversinglabs")
+                .WithVerbose(false)
+                .WithRaw(false)
+                .Build();
+            var response = await client.ReputationBulk(request);
+            </code>
+            </example>
+        </member>
         <member name="M:PangeaCyber.Net.Intel.FileIntelClient.CalculateSHA256fromFile(System.String)">
             
         </member>
@@ -5149,6 +5210,25 @@
             </code>
             </example>
         </member>
+        <member name="M:PangeaCyber.Net.Intel.IPIntelClient.GeolocateBulk(PangeaCyber.Net.Intel.IPGeolocateBulkRequest)">
+            <kind>method</kind>
+            <summary>Retrieve location information associated with a list of IP addresses.</summary>
+            <remarks>Geolocate V2</remarks>
+            <operationid>ip_intel_post_v2_geolocate</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.IPGeolocateBulkRequest">IPGeolocateBulkRequest with the ips to be looked up</param>
+            <returns>Response&lt;IPGeolocateBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] ips = new string[1] {"93.231.182.110"};
+            var request = new IPGeolocateBulkRequest.Builder(ips)
+                .WithProvider("digitalelement")
+                .WithVerbose(false)
+                .WithRaw(false)
+                .Build();
+            var response = await client.GeolocateBulk(request);
+            </code>
+            </example>
+        </member>
         <member name="M:PangeaCyber.Net.Intel.IPIntelClient.GetDomain(PangeaCyber.Net.Intel.IPDomainRequest)">
             <kind>method</kind>
             <summary>Retrieve the domain name associated with an IP address.</summary>
@@ -5165,6 +5245,25 @@
                 .WithRaw(false)
                 .Build();
             var response = await client.GetDomain(request);
+            </code>
+            </example>
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPIntelClient.GetDomainBulk(PangeaCyber.Net.Intel.IPDomainBulkRequest)">
+            <kind>method</kind>
+            <summary>Retrieve the domain names associated with a list of IP addresses.</summary>
+            <remarks>Domain V2</remarks>
+            <operationid>ip_intel_post_v2_domain</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.IPDomainBulkRequest">IPDomainBulkRequest with the ips to be looked up</param>
+            <returns>Response&lt;IPDomainBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] ips = new string[1] {"24.235.114.61"};
+            var request = new IPDomainBulkRequest.Builder(ips)
+                .WithProvider("digitalelement")
+                .WithVerbose(false)
+                .WithRaw(false)
+                .Build();
+            var response = await client.GetDomainBulk(request);
             </code>
             </example>
         </member>
@@ -5187,6 +5286,25 @@
             </code>
             </example>
         </member>
+        <member name="M:PangeaCyber.Net.Intel.IPIntelClient.IsVPNBulk(PangeaCyber.Net.Intel.IPVPNBulkRequest)">
+            <kind>method</kind>
+            <summary>Determine which IP addresses originate from a VPN.</summary>
+            <remarks>VPN V2</remarks>
+            <operationid>ip_intel_post_v2_vpn</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.IPVPNBulkRequest">IPVPNBulkRequest with the ips to be looked up</param>
+            <returns>Response&lt;IPVPNBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] ips = new string[1] {"2.56.189.74"};
+            var request = new IPVPNBulkRequest.Builder(ips)
+                .WithProvider("digitalelement")
+                .WithVerbose(false)
+                .WithRaw(false)
+                .Build();
+            var response = await client.IsVPNBulk(request);
+            </code>
+            </example>
+        </member>
         <member name="M:PangeaCyber.Net.Intel.IPIntelClient.IsProxy(PangeaCyber.Net.Intel.IPProxyRequest)">
             <kind>method</kind>
             <summary>Determine if an IP address originates from a proxy.</summary>
@@ -5203,6 +5321,25 @@
                 .WithRaw(false)
                 .Build();
             var response = await client.IsProxy(request);
+            </code>
+            </example>
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPIntelClient.IsProxyBulk(PangeaCyber.Net.Intel.IPProxyBulkRequest)">
+            <kind>method</kind>
+            <summary>Determine which IP addresses originate from a proxy.</summary>
+            <remarks>Proxy V2</remarks>
+            <operationid>ip_intel_post_v2_proxy</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.IPProxyBulkRequest">IPProxyBulkRequest with the ip to be looked up</param>
+            <returns>Response&lt;IPProxyBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] ips = new string[1] {"34.201.32.172"};
+            var request = new IPProxyBulkRequest.Builder(ips)
+                .WithProvider("digitalelement")
+                .WithVerbose(false)
+                .WithRaw(false)
+                .Build();
+            var response = await client.IsProxyBulk(request);
             </code>
             </example>
         </member>
@@ -5224,6 +5361,28 @@
             var response = await client.Reputation(request);
             </code>
             </example>
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPIntelClient.ReputationBulk(PangeaCyber.Net.Intel.IPReputationBulkRequest)">
+            <kind>method</kind>
+            <summary>Retrieve reputation scores for a list of IP addresses, from a provider, including an optional detailed report.</summary>
+            <remarks>Reputation V2</remarks>
+            <operationid>ip_intel_post_v2_reputation</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.IPReputationBulkRequest">IPReputationBulkRequest with the ip list to be looked up</param>
+            <returns>Response&lt;IPReputationBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] ips = new string[1] {"93.231.182.110"};
+            var request = new IPReputationBulkResult.Builder(ips)
+                .WithProvider("crowdstrike")
+                .WithVerbose(true)
+                .WithRaw(true)
+                .Build();
+            var response = await client.ReputationBulk(request);
+            </code>
+            </example>
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkData">
+            
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationData">
             
@@ -5273,6 +5432,9 @@
         <member name="M:PangeaCyber.Net.Intel.DomainWhoIsData.#ctor">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.FileReputationBulkData">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.FileReputationData">
             
         </member>
@@ -5309,6 +5471,9 @@
         <member name="M:PangeaCyber.Net.Intel.IntelReputationData.#ctor">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPDomainBulkData">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainData">
             
         </member>
@@ -5316,6 +5481,9 @@
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainData.Domain">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkData">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateData">
@@ -5339,13 +5507,22 @@
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateData.CountryCode">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPProxyBulkData">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyData">
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyData.IsProxy">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPReputationBulkData">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationData">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPVPNBulkData">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNData">
@@ -5366,7 +5543,13 @@
         <member name="F:PangeaCyber.Net.Intel.PasswordStatus.Inconclusive">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.URLReputationBulkData">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationData">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkData">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedData">
@@ -5378,6 +5561,9 @@
         <member name="P:PangeaCyber.Net.Intel.UserBreachedData.BreachCount">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkData">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedData">
             
         </member>
@@ -5385,6 +5571,27 @@
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedData.BreachCount">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Domains">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.DomainReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder.Domains">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.DomainReputationBulkRequest.Builder.Build">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationRequest">
@@ -5427,6 +5634,33 @@
             
         </member>
         <member name="M:PangeaCyber.Net.Intel.DomainWhoIsRequest.Builder.Build">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.FileHashReputationBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Hashes">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.HashType">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.Hashes">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.HashType">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.#ctor(System.String[],System.String)">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.FileHashReputationBulkRequest.Builder.Build">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileHashReputationRequest">
@@ -5498,6 +5732,27 @@
         <member name="M:PangeaCyber.Net.Intel.IntelCommonRequest`1.CommonBuilder.WithRaw(System.Nullable{System.Boolean})">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPDomainBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPDomainBulkRequest.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPDomainBulkRequest.#ctor(PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPDomainBulkRequest.Builder.Build">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainRequest">
             
         </member>
@@ -5517,6 +5772,27 @@
             
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPDomainRequest.Builder.Build">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.#ctor(PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPGeolocateBulkRequest.Builder.Build">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateRequest">
@@ -5540,6 +5816,27 @@
         <member name="M:PangeaCyber.Net.Intel.IPGeolocateRequest.Builder.Build">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPProxyBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPProxyBulkRequest.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPProxyBulkRequest.#ctor(PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPProxyBulkRequest.Builder.Build">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyRequest">
             
         </member>
@@ -5559,6 +5856,27 @@
             
         </member>
         <member name="M:PangeaCyber.Net.Intel.IPProxyRequest.Builder.Build">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPReputationBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPReputationBulkRequest.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPReputationBulkRequest.Builder.Build">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationRequest">
@@ -5582,6 +5900,27 @@
         <member name="M:PangeaCyber.Net.Intel.IPReputationRequest.Builder.Build">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPVPNBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPVPNBulkRequest.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPVPNBulkRequest.#ctor(PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder.IPs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.IPVPNBulkRequest.Builder.Build">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNRequest">
             
         </member>
@@ -5603,10 +5942,34 @@
         <member name="M:PangeaCyber.Net.Intel.IPVPNRequest.Builder.Build">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.URLReputationBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.URLReputationBulkRequest.URLs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.URLReputationBulkRequest.#ctor(PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder.URLs">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder.#ctor(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.URLReputationBulkRequest.Builder.Build">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationRequest">
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.URL">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.URLList">
             
         </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.#ctor(PangeaCyber.Net.Intel.URLReputationRequest.Builder)">
@@ -5618,10 +5981,82 @@
         <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.Builder.URL">
             
         </member>
+        <member name="P:PangeaCyber.Net.Intel.URLReputationRequest.Builder.URLList">
+            
+        </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.Builder.#ctor(System.String)">
             
         </member>
+        <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.Builder.#ctor(System.String[])">
+            
+        </member>
         <member name="M:PangeaCyber.Net.Intel.URLReputationRequest.Builder.Build">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Emails">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Usernames">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Ips">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.PhoneNumbers">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Start">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.End">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.#ctor(PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Emails">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Usernames">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Ips">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.PhoneNumbers">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Start">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.End">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.Build">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithEmails(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithUsernames(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithIPs(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithPhoneNumbers(System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithStart(System.String)">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserBreachedBulkRequest.Builder.WithEnd(System.String)">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedRequest">
@@ -5690,6 +6125,33 @@
         <member name="M:PangeaCyber.Net.Intel.UserBreachedRequest.Builder.WithEnd(System.String)">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.HashType">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.HashPrefixes">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.#ctor(PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder)">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.HashType">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.HashPrefixes">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.#ctor(PangeaCyber.Net.Intel.HashType,System.String[])">
+            
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest.Builder.Build">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedRequest">
             
         </member>
@@ -5717,6 +6179,12 @@
         <member name="M:PangeaCyber.Net.Intel.UserPasswordBreachedRequest.Builder.Build">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.DomainReputationBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.DomainReputationBulkResult.Data">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.DomainReputationResult">
             
         </member>
@@ -5727,6 +6195,12 @@
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.DomainWhoIsResult.Data">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.FileReputationBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.FileReputationBulkResult.Data">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.FileReputationResult">
@@ -5744,10 +6218,22 @@
         <member name="P:PangeaCyber.Net.Intel.IntelCommonResult.RawData">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPDomainBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPDomainBulkResult.Data">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPDomainResult">
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPDomainResult.Data">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPGeolocateBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPGeolocateBulkResult.Data">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPGeolocateResult">
@@ -5756,10 +6242,22 @@
         <member name="P:PangeaCyber.Net.Intel.IPGeolocateResult.Data">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPProxyBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPProxyBulkResult.Data">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPProxyResult">
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPProxyResult.Data">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.IPReputationBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPReputationBulkResult.Data">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.IPReputationResult">
@@ -5768,10 +6266,22 @@
         <member name="P:PangeaCyber.Net.Intel.IPReputationResult.Data">
             
         </member>
+        <member name="T:PangeaCyber.Net.Intel.IPVPNBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.IPVPNBulkResult.Data">
+            
+        </member>
         <member name="T:PangeaCyber.Net.Intel.IPVPNResult">
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.IPVPNResult.Data">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.URLReputationBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.URLReputationBulkResult.Data">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.URLReputationResult">
@@ -5780,13 +6290,22 @@
         <member name="P:PangeaCyber.Net.Intel.URLReputationResult.Data">
             
         </member>
-        <member name="M:PangeaCyber.Net.Intel.URLReputationResult.#ctor">
+        <member name="T:PangeaCyber.Net.Intel.UserBreachedBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserBreachedBulkResult.Data">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserBreachedResult">
             
         </member>
         <member name="P:PangeaCyber.Net.Intel.UserBreachedResult.Data">
+            
+        </member>
+        <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedBulkResult">
+            
+        </member>
+        <member name="P:PangeaCyber.Net.Intel.UserPasswordBreachedBulkResult.Data">
             
         </member>
         <member name="T:PangeaCyber.Net.Intel.UserPasswordBreachedResult">
@@ -5832,6 +6351,21 @@
             </code>
             </example>
         </member>
+        <member name="M:PangeaCyber.Net.Intel.URLIntelClient.ReputationBulk(PangeaCyber.Net.Intel.URLReputationBulkRequest)">
+            <kind>method</kind>
+            <summary>Retrieve reputation scores for a list of URLs, from a provider, including an optional detailed report.</summary>
+            <remarks>Reputation V2</remarks>
+            <operationid>url_intel_post_v2_reputation</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.URLReputationBulkRequest">URLReputationBulkRequest with the URL list to be looked up</param>
+            <returns>Response&lt;URLReputationBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] urls = new string[1] {"http://113.235.101.11:54384"};
+            var request = new URLReputationBulkRequest.Builder(urls).Build();
+            var response = await client.ReputationBulk(request);
+            </code>
+            </example>
+        </member>
         <member name="T:PangeaCyber.Net.Intel.UserIntelClient">
             <kind>class</kind>
             <summary>
@@ -5870,6 +6404,24 @@
             </code>
             </example>
         </member>
+        <member name="M:PangeaCyber.Net.Intel.UserIntelClient.BreachedBulk(PangeaCyber.Net.Intel.UserBreachedBulkRequest)">
+            <kind>method</kind>
+            <summary>Determine if an email address, username, phone number, or IP address was exposed in a security breach.</summary>
+            <remarks>Look up breached users V2</remarks>
+            <operationid>user_intel_post_v2_user_breached</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.UserBreachedBulkRequest">UserBreachedBulkRequest with the user data to be looked up</param>
+            <returns>Response&lt;UserBreachedBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] phoneNumbers = new string[1] {"8005550123"};
+            var request = new UserBreachedBulkRequest.Builder()
+                .WithPhoneNumbers(phoneNumbers)
+                .WithProvider("spycloud")
+                .Build();
+            var response = await client.BreachedBulk(request);
+            </code>
+            </example>
+        </member>
         <member name="M:PangeaCyber.Net.Intel.UserIntelClient.Breached(PangeaCyber.Net.Intel.UserPasswordBreachedRequest)">
             <kind>method</kind>
             <summary>Determine if a password has been exposed in a security breach using a 5 character prefix of the password hash.</summary>
@@ -5885,6 +6437,25 @@
                 .WithProvider("spycloud")
                 .Build();
             var response = await client.Breached(request);
+            </code>
+            </example>
+        </member>
+        <member name="M:PangeaCyber.Net.Intel.UserIntelClient.BreachedBulk(PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest)">
+            <kind>method</kind>
+            <summary>Determine if a password has been exposed in a security breach using a 5 character prefix of the password hash.</summary>
+            <remarks>Look up breached passwords V2</remarks>
+            <operationid>user_intel_post_v2_password_breached</operationid>
+            <param name="request" type="PangeaCyber.Net.Intel.UserPasswordBreachedBulkRequest">UserPasswordBreachedBulkRequest with the password hash to be looked up</param>
+            <returns>Response&lt;UserPasswordBreachedBulkResult&gt;</returns>
+            <example>
+            <code>
+            string[] hashPrefixes = new string[1] {"5baa6"};
+            var request = new UserPasswordBreachedBulkRequest.Builder(
+                HashType.SHA256,
+                hashPrefixes)
+                .WithProvider("spycloud")
+                .Build();
+            var response = await client.BreachedBulk(request);
             </code>
             </example>
         </member>
@@ -6324,9 +6895,6 @@
         <member name="T:PangeaCyber.Net.TransferMethod">
             
         </member>
-        <member name="F:PangeaCyber.Net.TransferMethod.Direct">
-            
-        </member>
         <member name="F:PangeaCyber.Net.TransferMethod.Multipart">
             
         </member>
@@ -6334,6 +6902,9 @@
             
         </member>
         <member name="F:PangeaCyber.Net.TransferMethod.PutURL">
+            
+        </member>
+        <member name="F:PangeaCyber.Net.TransferMethod.SourceURL">
             
         </member>
         <member name="T:PangeaCyber.Net.OrderedContractResolver">


### PR DESCRIPTION
I was working on getting the C# SDK docs updated then noticed `Client.Session.Invalidate` had the wrong operation ID.

The operation ID is being used to collate all the SDK code snippets to the OpenAPI spec endpoint equivalent. 