### PR TITLE
Refactor publish pipeline around Git tags (GEA-12975)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ default:
   tags:
     - pangea-internal
 
-.dotnet-sdk-base:
+.sdk-base:
   cache:
     paths:
       - "./packages/pangea-sdk/PangeaCyber.Net/obj/project.assets.json"
@@ -18,7 +18,7 @@ default:
     - dotnet restore --packages .nuget
     - dotnet build --no-restore --configuration Release
 
-.dotnet-sdk-test-base:
+.sdk-test-base:
   stage: integration_tests
   variables:
   # Set each service test environment
@@ -46,15 +46,15 @@ default:
     - echo ${CLOUD}
     - echo ${TEST}
 
-  # Update environment variables
-  # Domain
+    # Update environment variables
+    # Domain
     - export PANGEA_INTEGRATION_DOMAIN_${ENV}="$(eval echo \$PANGEA_INTEGRATION_DOMAIN_${ENV}_${CLOUD})"
-  # Tokens
+    # Tokens
     - export PANGEA_INTEGRATION_TOKEN_${ENV}="$(eval echo \$PANGEA_INTEGRATION_TOKEN_${ENV}_${CLOUD})"
     - export PANGEA_INTEGRATION_VAULT_TOKEN_${ENV}="$(eval echo \$PANGEA_INTEGRATION_VAULT_TOKEN_${ENV}_${CLOUD})"
     - export PANGEA_INTEGRATION_CUSTOM_SCHEMA_TOKEN_${ENV}="$(eval echo \$PANGEA_INTEGRATION_CUSTOM_SCHEMA_TOKEN_${ENV}_${CLOUD})"
     - export PANGEA_INTEGRATION_MULTI_CONFIG_TOKEN_${ENV}="$(eval echo \$PANGEA_INTEGRATION_MULTI_CONFIG_TOKEN_${ENV}_${CLOUD})"
-  # Config IDs
+    # Config IDs
     - export PANGEA_AUDIT_CONFIG_ID_1_${ENV}="$(eval echo \$PANGEA_AUDIT_CONFIG_ID_1_${ENV}_${CLOUD})"
     - export PANGEA_AUDIT_CONFIG_ID_2_${ENV}="$(eval echo \$PANGEA_AUDIT_CONFIG_ID_2_${ENV}_${CLOUD})"
     - export PANGEA_REDACT_CONFIG_ID_1_${ENV}="$(eval echo \$PANGEA_REDACT_CONFIG_ID_1_${ENV}_${CLOUD})"
@@ -100,32 +100,32 @@ default:
         ENV: ${SERVICE_VAULT_ENV}
         TEST: ITVaultTest
   rules:
-    - if: '$CLOUD == "GCP" && $TEST == "ITFileScanTest"'
+    - if: $CI_COMMIT_BRANCH && '$CLOUD == "GCP" && $TEST == "ITFileScanTest"'
       allow_failure: true
-    - if: '$CLOUD == "GCP" && $TEST != "ITFileScanTest"'
+    - if: $CI_COMMIT_BRANCH && '$CLOUD == "GCP" && $TEST != "ITFileScanTest"'
       allow_failure: false
-    - if: '$CLOUD != "GCP"'
+    - if: $CI_COMMIT_BRANCH && '$CLOUD != "GCP"'
       allow_failure: false
 
-dotnet-sdk-lint:
-  extends: .dotnet-sdk-base
+sdk-lint:
+  extends: .sdk-base
   stage: lint
   script:
     - dotnet format --verify-no-changes
 
-dotnet-sdk-unit-tests:
-  extends: .dotnet-sdk-base
+sdk-unit-tests:
+  extends: .sdk-base
   stage: unit_tests
   script:
     - dotnet test --no-restore --filter SignerTest
 
-dotnet-sdk-integration-tests:
-  extends: .dotnet-sdk-test-base
+sdk-integration-tests:
+  extends: .sdk-test-base
   script:
     - dotnet test --no-restore --filter ${TEST}
 
-.dotnet-sdk-staging-tests:
-  extends: .dotnet-sdk-test-base
+.sdk-staging-tests:
+  extends: .sdk-test-base
   variables:
     ENV: STG
   # Set each service test environment
@@ -144,9 +144,10 @@ dotnet-sdk-integration-tests:
     - dotnet test --no-restore
 
 publish:
-  extends: .dotnet-sdk-base
+  extends: .sdk-base
   stage: publish
   script:
+    - bash ../../dev/validate_tag.sh $CI_COMMIT_TAG
     - curl -s https://gitlab.com/gitlab-org/incubation-engineering/mobile-devops/download-secure-files/-/raw/main/installer | bash
     - PACKAGE_VERSION=`cat VERSION`
     - dotnet pack ./PangeaCyber.Net/ -c Release --no-build --nologo -o ./ -p:PackageVersion=$PACKAGE_VERSION
@@ -160,10 +161,7 @@ publish:
     paths:
       - packages/pangea-sdk/PangeaCyber.Net/bin/Release/Pangea.SDK.*.nupkg
   rules:
-    - if: $CI_COMMIT_BRANCH == "release"
-      changes:
-        - packages/pangea-sdk/**/*
-      when: on_success
+    - if: $CI_COMMIT_TAG
 
 stages:
   - lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Currently, the setup scripts only have support for Mac/ZSH environments.
+Future support is incoming.
+
+To install our linters, simply run `./dev/setup_repo.sh`
+These linters will run on every `git commit` operation.
+
+## Publishing
+
+Publishing Pangea.SDK to the NuGet registry is handled via a private GitLab CI
+pipeline. This pipeline is triggered when a Git tag is pushed to the repository.
+Git tags should be formatted as `vX.Y.Z`, where `vX.Y.Z` is the version number
+to publish.
+
+1. Update `<Version>` in `packages/pangea-sdk/PangeaCyber.Net/PangeaCyber.Net.csproj`.
+2. Update the version in `packages/pangea-sdk/VERSION`.
+3. Update the `Version` value in `packages/pangea-sdk/PangeaCyber.Net/Config.cs`.
+4. Update the release notes in `packages/pangea-sdk/CHANGELOG.md`.
+5. Author a commit with this change and land it on `main`.
+6. `git tag -m v1.0.0 v1.0.0 0000000`. Replace `v1.0.0` with the new version
+  number and `0000000` with the commit SHA from the previous step.
+7. `git push --tags origin main`.
+
+From here the GitLab CI pipeline will pick up the pushed Git tag and publish
+the package to the NuGet registry.

--- a/dev/validate_tag.sh
+++ b/dev/validate_tag.sh
@@ -17,6 +17,10 @@ fi
 # Trim the 'v'.
 GIT_TAG="${GIT_TAG:1}"
 
+# Move to repo root.
+PARENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
+pushd "$PARENT_PATH/.."
+
 CSPROJ_VERSION=$(grep -Eo "<Version>.+<\/Version>" packages/pangea-sdk/PangeaCyber.Net/PangeaCyber.Net.csproj)
 
 if [[ ! "$CSPROJ_VERSION" == *"$GIT_TAG"* ]]; then

--- a/dev/validate_tag.sh
+++ b/dev/validate_tag.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "usage: validate_tag.sh <git_tag>"
+    exit 1
+fi
+
+GIT_TAG=$1
+
+if [[ ! $GIT_TAG == "v"* ]]; then
+   echo "Git tag must begin with a 'v'."
+   exit 1
+fi
+
+# Trim the 'v'.
+GIT_TAG="${GIT_TAG:1}"
+
+CSPROJ_VERSION=$(grep -Eo "<Version>.+<\/Version>" packages/pangea-sdk/PangeaCyber.Net/PangeaCyber.Net.csproj)
+
+if [[ ! "$CSPROJ_VERSION" == *"$GIT_TAG"* ]]; then
+   echo "Git tag version '$GIT_TAG' does not match csproj file version '$CSPROJ_VERSION'."
+   exit 1
+fi
+
+CONFIG_VERSION=$(grep -Eo "public const string Version = ".+";" packages/pangea-sdk/PangeaCyber.Net/Config.cs)
+
+if [[ ! "$CONFIG_VERSION" == *"$GIT_TAG"* ]]; then
+   echo "Git tag version '$GIT_TAG' does not match Config class version '$CONFIG_VERSION'."
+   exit 1
+fi
+
+VERSION_FILE=$(cat packages/pangea-sdk/VERSION)
+
+if [[ ! "$GIT_TAG" == "$VERSION_FILE" ]]; then
+   echo "Git tag version '$GIT_TAG' does not match VERSION file version '$VERSION_FILE'."
+   exit 1
+fi

--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -74,3 +74,5 @@ examples:
   script:
     - cd examples/${EXAMPLE}
     - dotnet run
+  rules:
+    - if: $CI_COMMIT_BRANCH


### PR DESCRIPTION
Publishing to the NuGet registry is now triggered via the pushing of Git tags instead of requiring the use of the one `release` branch. This enables flexibility in publishing prerelease versions outside of the `release` branch and shaves one step off of the manual release process (merging to `release`).

Instructions on how to publish a new version going forward have been added to `CONTRIBUTING.md`.