### PR TITLE
Move CI cache setup to the default section (GEA-13332)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,6 @@ default:
     entrypoint: [""]
   tags:
     - pangea-internal
-
-.sdk-base:
   cache:
     paths:
       - "./packages/pangea-sdk/PangeaCyber.Net/obj/project.assets.json"
@@ -13,6 +11,7 @@ default:
       - "./packages/pangea-sdk/.nuget"
     policy: pull-push
 
+.sdk-base:
   before_script:
     - cd packages/pangea-sdk
     - dotnet restore --packages .nuget
@@ -34,13 +33,6 @@ default:
     SERVICE_REDACT_ENV: LVE
     SERVICE_VAULT_ENV: LVE
     SERVICE_SHARE_ENV: LVE
-
-  cache:
-    paths:
-      - "./packages/pangea-sdk/PangeaCyber.Net/obj/project.assets.json"
-      - "./packages/pangea-sdk/PangeaCyber.Net/obj/*.csproj.nuget.*"
-      - ".nuget"
-    policy: pull-push
 
   before_script:
     - echo ${ENV}


### PR DESCRIPTION
This way it'll apply to all jobs, even those like the examples CI which don't extend `.sdk-base`.