### PR TITLE
Remove .NET 7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [6, 7, 8]
+        dotnet-version: [6, 8]
     defaults:
       run:
         working-directory: ./packages/pangea-sdk
@@ -158,7 +158,7 @@ jobs:
     strategy:
       matrix:
         example: ${{ fromJSON(needs.setup.outputs.examples-matrix) }}
-        dotnet-version: [6, 7, 8]
+        dotnet-version: [6, 8]
     defaults:
       run:
         working-directory: ./examples/${{ matrix.example }}


### PR DESCRIPTION
.NET 7 went end-of-life on 2024-05-14.