### PR TITLE
Add `"state"` to `AuthN.Models.Authenticator` (PAN-15469)

### DIFF
--- a/packages/pangea-sdk/CHANGELOG.md
+++ b/packages/pangea-sdk/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `"state"` and other new properties to `AuthN.Models.Authenticator`.
+
 ### Changed
 
 - The `FirstName` and `LastName` properties of `AuthN.Models.Profile` are now
   deprecated.
+- `Enable` in `AuthN.Models.Authenticator` has been renamed to `Enabled`. The
+  previous name did not match the name used in the API's response schema and
+  JSON deserialization was not set up correctly, so `Enable` was unusable
+  anyways.
 
 ## [3.10.0] - 2024-06-20
 

--- a/packages/pangea-sdk/PangeaCyber.Net/AuthN/Models/Authenticator.cs
+++ b/packages/pangea-sdk/PangeaCyber.Net/AuthN/Models/Authenticator.cs
@@ -2,50 +2,58 @@ using Newtonsoft.Json;
 
 namespace PangeaCyber.Net.AuthN.Models
 {
-    /// <summary>
-    ///
-    /// </summary>
-    public class Authenticator
+    /// <summary>Authenticator.</summary>
+    public sealed class Authenticator
     {
-        /// <summary>
-        /// Gets or sets the id property.
-        /// </summary>
+        /// <summary>An ID for an authenticator.</summary>
         [JsonProperty("id")]
-        public string Id { get; private set; } = default!;
+        public string Id { get; set; } = default!;
 
-        /// <summary>
-        /// Gets or sets the type property.
-        /// </summary>
+        /// <summary>An authentication mechanism.</summary>
         [JsonProperty("type")]
-        public string Type { get; private set; } = default!;
+        public string Type { get; set; } = default!;
 
-        /// <summary>
-        /// Gets or sets the enable property.
-        /// </summary>
-        [JsonProperty("enable")]
-        public bool Enable { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the provider property.
-        /// </summary>
+        /// <summary>Provider.</summary>
         [JsonProperty("provider")]
-        public string? Provider { get; private set; }
+        public string? Provider { get; set; }
 
-        /// <summary>
-        /// Gets or sets the rpid property.
-        /// </summary>
+        /// <summary>Provider name.</summary>
+        [JsonProperty("provider_name")]
+        public string? ProviderName { get; set; }
+
+        /// <summary>RPID.</summary>
         [JsonProperty("rpid")]
-        public string? Rpid { get; private set; }
+        public string? Rpid { get; set; }
 
-        /// <summary>
-        /// Gets or sets the phase property.
-        /// </summary>
+        /// <summary>Enabled.</summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; } = default!;
+
+        /// <summary>Phase.</summary>
         [JsonProperty("phase")]
-        public string? Phase { get; private set; }
+        public string? Phase { get; set; }
 
-        /// <summary>
-        /// Default constructor for <see cref="Authenticator"/>.
-        /// </summary>
+        /// <summary>Enrolling browser.</summary>
+        [JsonProperty("enrolling_browser")]
+        public string? EnrollingBrowser { get; set; }
+
+        /// <summary>Enrolling IP.</summary>
+        [JsonProperty("enrolling_ip")]
+        public string? EnrollingIp { get; set; }
+
+        /// <summary>A time in ISO-8601 format.</summary>
+        [JsonProperty("created_at")]
+        public string CreatedAt { get; set; } = default!;
+
+        /// <summary>A time in ISO-8601 format.</summary>
+        [JsonProperty("updated_at")]
+        public string UpdatedAt { get; set; } = default!;
+
+        /// <summary>State.</summary>
+        [JsonProperty("state")]
+        public string? State { get; set; }
+
+        /// <summary>Default constructor for <see cref="Authenticator"/>.</summary>
         public Authenticator() { }
     }
 }

--- a/packages/pangea-sdk/PangeaCyber.Net/AuthN/Results/UserAuthenticatorsListResult.cs
+++ b/packages/pangea-sdk/PangeaCyber.Net/AuthN/Results/UserAuthenticatorsListResult.cs
@@ -8,9 +8,7 @@ namespace PangeaCyber.Net.AuthN.Results
     /// </summary>
     public class UserAuthenticatorsListResult
     {
-        /// <summary>
-        /// Gets or sets the authenticators property.
-        /// </summary>
+        /// <summary>A list of authenticators.</summary>
         [JsonProperty("authenticators")]
         public Authenticator[] Authenticators { get; private set; } = default!;
 


### PR DESCRIPTION
Also added other missing properties. Many of these do not have descriptions in the API documentation so the docs here are skim.

`Enable` has been renamed to `Enabled` to match the API's response schema. This is a breaking change but the current property isn't being deserialized properly anyways so it's been unusable this whole time.