### PR TITLE
Downgrade typescript to v5.5.4 (PAN-16846)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@types/node": "20.16.5",
     "@vitest/coverage-v8": "2.1.1",
     "tsimp": "2.0.11",
-    "typescript": "5.6.2",
+    "typescript": "5.5.4",
     "vitest": "2.1.1"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -331,7 +331,7 @@ __metadata:
     fast-xml-parser: "npm:4.5.0"
     js-yaml: "npm:4.1.0"
     tsimp: "npm:2.0.11"
-    typescript: "npm:5.6.2"
+    typescript: "npm:5.5.4"
     vitest: "npm:2.1.1"
   languageName: unknown
   linkType: soft
@@ -1859,23 +1859,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.6.2":
-  version: 5.6.2
-  resolution: "typescript@npm:5.6.2"
+"typescript@npm:5.5.4":
+  version: 5.5.4
+  resolution: "typescript@npm:5.5.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/3ed8297a8c7c56b7fec282532503d1ac795239d06e7c4966b42d4330c6cf433a170b53bcf93a130a7f14ccc5235de5560df4f1045eb7f3550b46ebed16d3c5e5
+  checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>":
-  version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
+"typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>":
+  version: 5.5.4
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
+  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes the docs job until tsimp is updated to work with typescript v5.6.2.