### PR TITLE
Fix a NRE in Audit event verification

### DIFF
--- a/packages/pangea-sdk/CHANGELOG.md
+++ b/packages/pangea-sdk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Audit: a `NullReferenceException` that could happen during verification.
 - Redact: incorrect `RedactionMethodOverrides.RedactionType` serialization.
 
 ## 5.1.0 - 2025-04-25

--- a/packages/pangea-sdk/PangeaCyber.Net/Audit/arweave/Arweave.cs
+++ b/packages/pangea-sdk/PangeaCyber.Net/Audit/arweave/Arweave.cs
@@ -129,7 +129,7 @@ namespace PangeaCyber.Net.Audit.arweave
             return response;
         }
 
-        private async Task<HttpResponseMessage> doGet(string url)
+        private async Task<HttpResponseMessage?> doGet(string url)
         {
             using var localClient = new HttpClient();
             HttpResponseMessage httpResponse;
@@ -140,7 +140,7 @@ namespace PangeaCyber.Net.Audit.arweave
             }
             catch (Exception)
             {
-                return default!;
+                return default;
             }
 
             if (httpResponse.StatusCode == System.Net.HttpStatusCode.Found)
@@ -150,16 +150,21 @@ namespace PangeaCyber.Net.Audit.arweave
 
             if (httpResponse.StatusCode != System.Net.HttpStatusCode.OK)
             {
-                return default!;
+                return default;
             }
 
             return httpResponse;
         }
 
-        private async Task<PublishedRoot> doGetRoot(string nodeID)
+        private async Task<PublishedRoot?> doGetRoot(string nodeID)
         {
-            HttpResponseMessage httpResponse = await doGet(getTransactionURL(nodeID));
-            string body = await httpResponse.Content.ReadAsStringAsync();
+            var httpResponse = await doGet(getTransactionURL(nodeID));
+            if (httpResponse == null)
+            {
+                return default;
+            }
+
+            var body = await httpResponse.Content.ReadAsStringAsync();
             PublishedRoot root;
             try
             {
@@ -168,7 +173,7 @@ namespace PangeaCyber.Net.Audit.arweave
             }
             catch (Exception)
             {
-                return default!;
+                return default;
             }
 
             return root;
@@ -199,7 +204,7 @@ namespace PangeaCyber.Net.Audit.arweave
 
                     if (value != null)
                     {
-                        PublishedRoot root = await doGetRoot(nodeID);
+                        var root = await doGetRoot(nodeID);
                         if (root != null)
                         {
                             try


### PR DESCRIPTION
The `default!`s here were cheating. These methods say they return non-nullable `HttpResponseMessage` or `PublishedRoot`, but they actually **can** return `null` because of these `default!`s.